### PR TITLE
Add ARIA labels and semantic roles to interactive elements

### DIFF
--- a/frontend/src/components/board/card-detail-aria.test.tsx
+++ b/frontend/src/components/board/card-detail-aria.test.tsx
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/preact';
+import { CardDetail } from './card-detail';
+import { AuthContext } from '../../auth/auth-context';
+import type { AuthState } from '../../auth/auth-context';
+
+afterEach(() => {
+  cleanup();
+});
+
+let mockSelectedItemId: string | null = 'aria-test-1';
+
+vi.mock('../../state/board-store', () => ({
+  selectedItemId: {
+    get value() { return mockSelectedItemId; },
+    set value(v: string | null) { mockSelectedItemId = v; },
+  },
+  selectedItem: {
+    get value() {
+      if (!mockSelectedItemId) return null;
+      return {
+        id: mockSelectedItemId,
+        title: 'Test Item',
+        description: 'A test description',
+        status: 'To Do',
+        owner: 'Luke',
+        due_date: '',
+        scheduled_date: '',
+        labels: '',
+        parent_id: '',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+        completed_at: '',
+        sort_order: 1,
+        sheetRow: 2,
+      };
+    },
+  },
+  childrenOfSelected: {
+    get value() {
+      return [
+        {
+          id: 'child-1',
+          title: 'Buy milk',
+          description: '',
+          status: 'To Do',
+          owner: '',
+          due_date: '',
+          scheduled_date: '',
+          labels: '',
+          parent_id: mockSelectedItemId,
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-01T00:00:00Z',
+          completed_at: '',
+          sort_order: 1,
+          sheetRow: 3,
+        },
+        {
+          id: 'child-2',
+          title: 'Buy bread',
+          description: '',
+          status: 'Done',
+          owner: 'Luke',
+          due_date: '',
+          scheduled_date: '',
+          labels: '',
+          parent_id: mockSelectedItemId,
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-01T00:00:00Z',
+          completed_at: '2026-01-02T00:00:00Z',
+          sort_order: 2,
+          sheetRow: 4,
+        },
+      ];
+    },
+  },
+  items: { value: [] },
+  owners: { value: [{ name: 'Luke', google_account: 'luke@example.com' }] },
+  labels: { value: [] },
+}));
+
+vi.mock('../../state/actions', () => ({
+  updateItem: vi.fn(),
+  deleteItem: vi.fn(),
+  createItem: vi.fn(),
+  moveItem: vi.fn(),
+}));
+
+const mockAuth: AuthState = {
+  token: 'test-token',
+  user: { name: 'Luke', email: 'luke@example.com', picture: '' },
+  isAuthenticated: true,
+  login: () => {},
+  logout: () => {},
+};
+
+function renderCardDetail() {
+  return render(
+    <AuthContext.Provider value={mockAuth}>
+      <CardDetail />
+    </AuthContext.Provider>
+  );
+}
+
+describe('CardDetail ARIA labels (Issue #7)', () => {
+  beforeEach(() => {
+    mockSelectedItemId = 'aria-test-1';
+  });
+
+  // AC3: Detail panel close button has accessible label
+  describe('AC3: Close button has accessible label', () => {
+    it('close button has aria-label="Close"', () => {
+      const { container } = renderCardDetail();
+      const closeBtn = container.querySelector('.detail-header .btn-ghost') as HTMLElement;
+      expect(closeBtn).not.toBeNull();
+      expect(closeBtn.getAttribute('aria-label')).toBe('Close');
+    });
+  });
+
+  // AC5: Subtask checkboxes have accessible labels
+  describe('AC5: Subtask checkboxes have accessible labels', () => {
+    it('each subtask checkbox has aria-label matching the subtask title', () => {
+      const { container } = renderCardDetail();
+      const checkboxes = container.querySelectorAll('.subtask-list input[type="checkbox"]');
+      expect(checkboxes.length).toBe(2);
+      expect((checkboxes[0] as HTMLInputElement).getAttribute('aria-label')).toBe('Buy milk');
+      expect((checkboxes[1] as HTMLInputElement).getAttribute('aria-label')).toBe('Buy bread');
+    });
+  });
+
+  // AC6: Editable fields have accessible roles
+  describe('AC6: Editable fields have accessible roles', () => {
+    it('title editable field has role="button" and aria-label="Edit title"', () => {
+      const { container } = renderCardDetail();
+      const editableValues = container.querySelectorAll('.editable-value');
+      // First editable field is Title
+      const titleField = editableValues[0] as HTMLElement;
+      expect(titleField.getAttribute('role')).toBe('button');
+      expect(titleField.getAttribute('aria-label')).toBe('Edit title');
+    });
+
+    it('description editable field has role="button" and aria-label="Edit description"', () => {
+      const { container } = renderCardDetail();
+      const editableValues = container.querySelectorAll('.editable-value');
+      // Second editable field is Description
+      const descField = editableValues[1] as HTMLElement;
+      expect(descField.getAttribute('role')).toBe('button');
+      expect(descField.getAttribute('aria-label')).toBe('Edit description');
+    });
+
+    it('editable fields have tabIndex=0 for keyboard access', () => {
+      const { container } = renderCardDetail();
+      const editableValues = container.querySelectorAll('.editable-value');
+      expect((editableValues[0] as HTMLElement).getAttribute('tabindex')).toBe('0');
+      expect((editableValues[1] as HTMLElement).getAttribute('tabindex')).toBe('0');
+    });
+
+    it('pressing Enter on editable field activates edit mode', () => {
+      const { container } = renderCardDetail();
+      const titleField = container.querySelector('.editable-value') as HTMLElement;
+      expect(titleField.getAttribute('role')).toBe('button');
+
+      // Press Enter to activate
+      fireEvent.keyDown(titleField, { key: 'Enter' });
+
+      // After activation, the editable-value should be replaced with an input
+      const input = container.querySelector('.detail-field input[type="text"]') as HTMLInputElement;
+      expect(input).not.toBeNull();
+    });
+
+    it('pressing Space on editable field activates edit mode', () => {
+      const { container } = renderCardDetail();
+      const titleField = container.querySelector('.editable-value') as HTMLElement;
+
+      // Press Space to activate
+      fireEvent.keyDown(titleField, { key: ' ' });
+
+      // After activation, the editable-value should be replaced with an input
+      const input = container.querySelector('.detail-field input[type="text"]') as HTMLInputElement;
+      expect(input).not.toBeNull();
+    });
+  });
+
+  // Dialog role (already existed, verify it's still present)
+  describe('Dialog role and aria-modal', () => {
+    it('detail overlay has role="dialog" and aria-modal="true"', () => {
+      const { container } = renderCardDetail();
+      const overlay = container.querySelector('.detail-overlay') as HTMLElement;
+      expect(overlay.getAttribute('role')).toBe('dialog');
+      expect(overlay.getAttribute('aria-modal')).toBe('true');
+      expect(overlay.getAttribute('aria-label')).toBe('Item Details');
+    });
+  });
+});

--- a/frontend/src/components/board/card-detail.tsx
+++ b/frontend/src/components/board/card-detail.tsx
@@ -71,7 +71,7 @@ export function CardDetail() {
       <div class="detail-panel">
         <div class="detail-header">
           <h2>Item Details</h2>
-          <button class="btn btn-ghost" onClick={close}>✕</button>
+          <button class="btn btn-ghost" aria-label="Close" onClick={close}>✕</button>
         </div>
 
         <div class="detail-body">
@@ -171,6 +171,7 @@ export function CardDetail() {
                     <input
                       type="checkbox"
                       checked={child.status === 'Done'}
+                      aria-label={child.title}
                       onChange={() => toggleChildStatus(child.id, child.status)}
                     />
                     <span>{child.title}</span>
@@ -223,7 +224,19 @@ function EditableField({ label, value, onSave, multiline }: {
     return (
       <div class="detail-field" onClick={() => { setDraft(value); setEditing(true); }}>
         <label>{label}</label>
-        <div class="editable-value">
+        <div
+          class="editable-value"
+          role="button"
+          tabIndex={0}
+          aria-label={`Edit ${label.toLowerCase()}`}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              setDraft(value);
+              setEditing(true);
+            }
+          }}
+        >
           {value || <span class="placeholder">Click to edit</span>}
         </div>
       </div>

--- a/frontend/src/components/board/column.test.tsx
+++ b/frontend/src/components/board/column.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/preact';
+import { Column } from './column';
+import type { ItemWithRow } from '../../api/types';
+
+afterEach(() => {
+  cleanup();
+});
+
+// Mock board-store for Card dependency
+vi.mock('../../state/board-store', () => ({
+  selectedItemId: { value: null },
+  labels: { value: [] },
+  getChildCount: () => ({ done: 0, total: 0 }),
+}));
+
+function makeItem(overrides: Partial<ItemWithRow> = {}): ItemWithRow {
+  return {
+    id: 'test-1',
+    title: 'Test Item',
+    description: '',
+    status: 'To Do',
+    owner: '',
+    due_date: '',
+    scheduled_date: '',
+    labels: '',
+    parent_id: '',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    completed_at: '',
+    sort_order: 1,
+    sheetRow: 2,
+    ...overrides,
+  };
+}
+
+describe('Column ARIA roles (Issue #7)', () => {
+  // AC4: Columns have region roles
+  describe('AC4: Columns have region roles', () => {
+    it('has role="region"', () => {
+      const { container } = render(
+        <Column status="To Do" items={[]} onDrop={vi.fn()} />
+      );
+      const column = container.querySelector('.column') as HTMLElement;
+      expect(column.getAttribute('role')).toBe('region');
+    });
+
+    it('has aria-label with status and item count (plural)', () => {
+      const items = [
+        makeItem({ id: '1', title: 'Task 1' }),
+        makeItem({ id: '2', title: 'Task 2' }),
+        makeItem({ id: '3', title: 'Task 3' }),
+      ];
+      const { container } = render(
+        <Column status="To Do" items={items} onDrop={vi.fn()} />
+      );
+      const column = container.querySelector('.column') as HTMLElement;
+      expect(column.getAttribute('aria-label')).toBe('To Do column, 3 items');
+    });
+
+    it('has aria-label with singular "item" for 1 item', () => {
+      const items = [makeItem({ id: '1', title: 'Task 1' })];
+      const { container } = render(
+        <Column status="In Progress" items={items} onDrop={vi.fn()} />
+      );
+      const column = container.querySelector('.column') as HTMLElement;
+      expect(column.getAttribute('aria-label')).toBe('In Progress column, 1 item');
+    });
+
+    it('has aria-label with 0 items', () => {
+      const { container } = render(
+        <Column status="Done" items={[]} onDrop={vi.fn()} />
+      );
+      const column = container.querySelector('.column') as HTMLElement;
+      expect(column.getAttribute('aria-label')).toBe('Done column, 0 items');
+    });
+  });
+});

--- a/frontend/src/components/board/column.tsx
+++ b/frontend/src/components/board/column.tsx
@@ -37,6 +37,8 @@ export function Column({ status, items, onDrop, onMoveStatus, compact }: Props) 
   return (
     <div
       class={`column ${compact ? 'column-compact' : ''}`}
+      role="region"
+      aria-label={`${status} column, ${items.length} ${items.length === 1 ? 'item' : 'items'}`}
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}

--- a/frontend/src/components/board/kanban-board.test.tsx
+++ b/frontend/src/components/board/kanban-board.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/preact';
+import { KanbanBoard } from './kanban-board';
+import { AuthContext } from '../../auth/auth-context';
+import type { AuthState } from '../../auth/auth-context';
+
+afterEach(() => {
+  cleanup();
+});
+
+vi.mock('../../state/board-store', () => ({
+  columns: {
+    value: {
+      'To Do': [],
+      'In Progress': [],
+      'Done': [],
+    },
+  },
+  showCreateModal: { value: false },
+  selectedItem: { value: null },
+  selectedItemId: { value: null },
+  groupBy: { value: 'none' },
+  rootItems: { value: [] },
+  owners: { value: [] },
+  labels: { value: [] },
+  filterOwner: { value: null },
+  filterLabel: { value: null },
+}));
+
+vi.mock('../../state/actions', () => ({
+  moveItem: vi.fn(),
+}));
+
+const mockAuth: AuthState = {
+  token: 'test-token',
+  user: { name: 'Luke', email: 'luke@example.com', picture: '' },
+  isAuthenticated: true,
+  login: () => {},
+  logout: () => {},
+};
+
+function renderBoard() {
+  return render(
+    <AuthContext.Provider value={mockAuth}>
+      <KanbanBoard />
+    </AuthContext.Provider>
+  );
+}
+
+describe('KanbanBoard ARIA labels (Issue #7)', () => {
+  // AC2: FAB has accessible label
+  describe('AC2: FAB has accessible label', () => {
+    it('FAB button has aria-label="Create new item"', () => {
+      const { container } = renderBoard();
+      const fab = container.querySelector('.fab') as HTMLElement;
+      expect(fab).not.toBeNull();
+      expect(fab.getAttribute('aria-label')).toBe('Create new item');
+    });
+
+    it('FAB button has title="Create new item"', () => {
+      const { container } = renderBoard();
+      const fab = container.querySelector('.fab') as HTMLElement;
+      expect(fab.getAttribute('title')).toBe('Create new item');
+    });
+  });
+});

--- a/frontend/src/components/board/kanban-board.tsx
+++ b/frontend/src/components/board/kanban-board.tsx
@@ -107,6 +107,7 @@ export function KanbanBoard() {
         class="fab"
         onClick={() => { showCreateModal.value = true; }}
         title="Create new item"
+        aria-label="Create new item"
       >
         +
       </button>

--- a/frontend/src/components/filters/filter-bar.test.tsx
+++ b/frontend/src/components/filters/filter-bar.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/preact';
+import { FilterBar } from './filter-bar';
+
+afterEach(() => {
+  cleanup();
+});
+
+vi.mock('../../state/board-store', () => ({
+  filterOwner: { value: null },
+  filterLabel: { value: null },
+  groupBy: { value: 'none' },
+  owners: { value: [{ name: 'Luke', google_account: 'luke@example.com' }] },
+  labels: { value: [{ label: 'Urgent', color: '#ff0000' }] },
+}));
+
+describe('FilterBar ARIA labels (Issue #7)', () => {
+  // AC1: Filter bar selects have accessible labels
+  describe('AC1: Filter bar selects have accessible labels', () => {
+    it('owner select has aria-label "Filter by owner"', () => {
+      const { container } = render(<FilterBar />);
+      const selects = container.querySelectorAll('select');
+      const ownerSelect = selects[0] as HTMLSelectElement;
+      expect(ownerSelect.getAttribute('aria-label')).toBe('Filter by owner');
+    });
+
+    it('label select has aria-label "Filter by label"', () => {
+      const { container } = render(<FilterBar />);
+      const selects = container.querySelectorAll('select');
+      const labelSelect = selects[1] as HTMLSelectElement;
+      expect(labelSelect.getAttribute('aria-label')).toBe('Filter by label');
+    });
+
+    it('group-by select has aria-label "Group items by"', () => {
+      const { container } = render(<FilterBar />);
+      const selects = container.querySelectorAll('select');
+      const groupBySelect = selects[2] as HTMLSelectElement;
+      expect(groupBySelect.getAttribute('aria-label')).toBe('Group items by');
+    });
+  });
+});

--- a/frontend/src/components/filters/filter-bar.tsx
+++ b/frontend/src/components/filters/filter-bar.tsx
@@ -7,6 +7,7 @@ export function FilterBar() {
     <div class="filter-bar">
       <div class="filter-group">
         <select
+          aria-label="Filter by owner"
           value={filterOwner.value || ''}
           onChange={(e) => {
             filterOwner.value = (e.target as HTMLSelectElement).value || null;
@@ -19,6 +20,7 @@ export function FilterBar() {
         </select>
 
         <select
+          aria-label="Filter by label"
           value={filterLabel.value || ''}
           onChange={(e) => {
             filterLabel.value = (e.target as HTMLSelectElement).value || null;
@@ -31,6 +33,7 @@ export function FilterBar() {
         </select>
 
         <select
+          aria-label="Group items by"
           value={groupBy.value}
           onChange={(e) => {
             groupBy.value = (e.target as HTMLSelectElement).value as any;

--- a/frontend/src/components/shared/toast.test.tsx
+++ b/frontend/src/components/shared/toast.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, cleanup } from '@testing-library/preact';
+import { Toast } from './toast';
+
+afterEach(() => {
+  cleanup();
+});
+
+// Provide a mutable reference for the mock
+let mockToastMessage: { text: string; type: 'success' | 'error' } | null = null;
+
+vi.mock('../../state/board-store', () => ({
+  toastMessage: {
+    get value() { return mockToastMessage; },
+  },
+}));
+
+describe('Toast ARIA roles (Issue #7)', () => {
+  beforeEach(() => {
+    mockToastMessage = null;
+  });
+
+  it('has role="status" when visible', () => {
+    mockToastMessage = { text: 'Item saved', type: 'success' };
+    const { container } = render(<Toast />);
+    const toast = container.querySelector('.toast') as HTMLElement;
+    expect(toast).not.toBeNull();
+    expect(toast.getAttribute('role')).toBe('status');
+  });
+
+  it('has aria-live="polite" when visible', () => {
+    mockToastMessage = { text: 'Item saved', type: 'success' };
+    const { container } = render(<Toast />);
+    const toast = container.querySelector('.toast') as HTMLElement;
+    expect(toast.getAttribute('aria-live')).toBe('polite');
+  });
+
+  it('renders nothing when there is no message', () => {
+    mockToastMessage = null;
+    const { container } = render(<Toast />);
+    const toast = container.querySelector('.toast');
+    expect(toast).toBeNull();
+  });
+});

--- a/frontend/src/components/shared/toast.tsx
+++ b/frontend/src/components/shared/toast.tsx
@@ -5,7 +5,7 @@ export function Toast() {
   if (!msg) return null;
 
   return (
-    <div class={`toast toast-${msg.type}`}>
+    <div class={`toast toast-${msg.type}`} role="status" aria-live="polite">
       {msg.text}
     </div>
   );


### PR DESCRIPTION
## Summary
- Add `aria-label` attributes to filter bar selects, FAB button, detail panel close button, subtask checkboxes, and editable fields
- Add `role="region"` with descriptive labels (including item count) to board columns
- Add `role="button"` and keyboard activation (Enter/Space) to click-to-edit fields
- Add `role="status"` and `aria-live="polite"` to toast notifications

Closes #7

## Test plan
- [x] AC1: Filter bar selects have accessible labels ("Filter by owner", "Filter by label", "Group items by")
- [x] AC2: FAB has `aria-label="Create new item"`
- [x] AC3: Close button has `aria-label="Close"`
- [x] AC4: Columns have `role="region"` with label like "To Do column, 3 items"
- [x] AC5: Subtask checkboxes have `aria-label` matching subtask title
- [x] AC6: Editable fields have `role="button"` and `aria-label="Edit title"` / `"Edit description"`
- [x] All 53 frontend tests pass
- [x] All 12 apps-script tests pass
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)