### PR TITLE
Replace browser confirm/prompt dialogs with inline UI

### DIFF
--- a/frontend/src/components/board/card-detail.test.tsx
+++ b/frontend/src/components/board/card-detail.test.tsx
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, fireEvent, cleanup } from '@testing-library/preact';
+import { render, fireEvent, cleanup, waitFor } from '@testing-library/preact';
 import { CardDetail } from './card-detail';
 import { AuthContext } from '../../auth/auth-context';
 import type { AuthState } from '../../auth/auth-context';
+import { deleteItem, createItem } from '../../state/actions';
 
 afterEach(() => {
   cleanup();
@@ -178,6 +179,238 @@ describe('CardDetail keyboard accessibility (Issue #6)', () => {
       // Click directly on the overlay (not the panel)
       fireEvent.click(overlay);
       expect(mockSelectedItemId).toBeNull();
+    });
+  });
+});
+
+describe('CardDetail inline dialogs (Issue #9)', () => {
+  beforeEach(() => {
+    mockSelectedItemId = 'detail-test-1';
+    vi.clearAllMocks();
+  });
+
+  // AC1: Delete confirmation is inline (not browser confirm())
+  describe('AC1: Delete confirmation is inline', () => {
+    it('shows inline confirmation UI when Delete is clicked instead of browser confirm()', () => {
+      const { container } = renderCardDetail();
+
+      // Click the Delete button
+      const deleteBtn = container.querySelector('.detail-footer .btn-danger') as HTMLElement;
+      expect(deleteBtn).not.toBeNull();
+      expect(deleteBtn.textContent).toBe('Delete');
+      fireEvent.click(deleteBtn);
+
+      // Inline confirmation should appear
+      const confirmInline = container.querySelector('.delete-confirm-inline') as HTMLElement;
+      expect(confirmInline).not.toBeNull();
+      expect(confirmInline.querySelector('.delete-confirm-text')!.textContent).toBe('Are you sure?');
+
+      // Should have Cancel and Delete buttons
+      const buttons = confirmInline.querySelectorAll('button');
+      expect(buttons.length).toBe(2);
+      expect(buttons[0].textContent).toBe('Cancel');
+      expect(buttons[1].textContent).toBe('Delete');
+    });
+
+    it('does not call browser confirm()', () => {
+      const confirmSpy = vi.spyOn(window, 'confirm');
+      const { container } = renderCardDetail();
+
+      const deleteBtn = container.querySelector('.detail-footer .btn-danger') as HTMLElement;
+      fireEvent.click(deleteBtn);
+
+      expect(confirmSpy).not.toHaveBeenCalled();
+      confirmSpy.mockRestore();
+    });
+
+    it('calls deleteItem and closes panel when inline Delete is confirmed', () => {
+      const { container } = renderCardDetail();
+
+      // Click Delete to show confirmation
+      const deleteBtn = container.querySelector('.detail-footer .btn-danger') as HTMLElement;
+      fireEvent.click(deleteBtn);
+
+      // Click the confirm Delete button
+      const confirmBtn = container.querySelector('.delete-confirm-inline .btn-danger') as HTMLElement;
+      fireEvent.click(confirmBtn);
+
+      expect(deleteItem).toHaveBeenCalledWith('detail-test-1', 'Luke', 'test-token');
+      expect(mockSelectedItemId).toBeNull();
+    });
+  });
+
+  // AC2: Delete can be cancelled
+  describe('AC2: Delete can be cancelled', () => {
+    it('dismisses confirmation when Cancel is clicked', () => {
+      const { container } = renderCardDetail();
+
+      // Show confirmation
+      const deleteBtn = container.querySelector('.detail-footer .btn-danger') as HTMLElement;
+      fireEvent.click(deleteBtn);
+      expect(container.querySelector('.delete-confirm-inline')).not.toBeNull();
+
+      // Click Cancel
+      const cancelBtn = container.querySelector('.delete-confirm-inline .btn-ghost') as HTMLElement;
+      fireEvent.click(cancelBtn);
+
+      // Confirmation should be dismissed
+      expect(container.querySelector('.delete-confirm-inline')).toBeNull();
+      // The Delete button should be back
+      expect(container.querySelector('.detail-footer .btn-danger')).not.toBeNull();
+      // Item should not be deleted
+      expect(deleteItem).not.toHaveBeenCalled();
+    });
+
+    it('dismisses confirmation when Escape is pressed on the confirmation area', () => {
+      const { container } = renderCardDetail();
+
+      // Show confirmation
+      const deleteBtn = container.querySelector('.detail-footer .btn-danger') as HTMLElement;
+      fireEvent.click(deleteBtn);
+
+      // Press Escape on the confirmation area
+      const confirmInline = container.querySelector('.delete-confirm-inline') as HTMLElement;
+      fireEvent.keyDown(confirmInline, { key: 'Escape' });
+
+      // Confirmation should be dismissed
+      expect(container.querySelector('.delete-confirm-inline')).toBeNull();
+      expect(deleteItem).not.toHaveBeenCalled();
+    });
+  });
+
+  // AC3: Subtask creation is inline (not browser prompt())
+  describe('AC3: Subtask creation is inline', () => {
+    it('shows inline text input when + Add is clicked instead of browser prompt()', () => {
+      const { container } = renderCardDetail();
+
+      // Click + Add
+      const addBtn = container.querySelector('.detail-subtasks-header .btn-sm') as HTMLElement;
+      expect(addBtn).not.toBeNull();
+      expect(addBtn.textContent).toBe('+ Add');
+      fireEvent.click(addBtn);
+
+      // Inline input should appear
+      const input = container.querySelector('.subtask-add-input') as HTMLInputElement;
+      expect(input).not.toBeNull();
+      expect(input.placeholder).toBe('Sub-task title...');
+    });
+
+    it('does not call browser prompt()', () => {
+      const promptSpy = vi.spyOn(window, 'prompt');
+      const { container } = renderCardDetail();
+
+      const addBtn = container.querySelector('.detail-subtasks-header .btn-sm') as HTMLElement;
+      fireEvent.click(addBtn);
+
+      expect(promptSpy).not.toHaveBeenCalled();
+      promptSpy.mockRestore();
+    });
+
+    it('hides + Add button while input is visible', () => {
+      const { container } = renderCardDetail();
+
+      const addBtn = container.querySelector('.detail-subtasks-header .btn-sm') as HTMLElement;
+      fireEvent.click(addBtn);
+
+      // + Add button should be hidden
+      expect(container.querySelector('.detail-subtasks-header .btn-sm')).toBeNull();
+    });
+  });
+
+  // AC4: Subtask creation submits on Enter
+  describe('AC4: Subtask creation submits on Enter', () => {
+    it('creates subtask and closes input when Enter is pressed with text', () => {
+      const { container } = renderCardDetail();
+
+      // Open inline input
+      const addBtn = container.querySelector('.detail-subtasks-header .btn-sm') as HTMLElement;
+      fireEvent.click(addBtn);
+
+      const input = container.querySelector('.subtask-add-input') as HTMLInputElement;
+
+      // Type a title
+      fireEvent.input(input, { target: { value: 'New subtask' } });
+
+      // Press Enter
+      fireEvent.keyDown(input, { key: 'Enter' });
+
+      expect(createItem).toHaveBeenCalledWith(
+        { title: 'New subtask', parent_id: 'detail-test-1', owner: 'Luke' },
+        'Luke',
+        'test-token'
+      );
+
+      // Input should close
+      expect(container.querySelector('.subtask-add-input')).toBeNull();
+    });
+
+    it('does not create subtask if input is empty on Enter', () => {
+      const { container } = renderCardDetail();
+
+      // Open inline input
+      const addBtn = container.querySelector('.detail-subtasks-header .btn-sm') as HTMLElement;
+      fireEvent.click(addBtn);
+
+      const input = container.querySelector('.subtask-add-input') as HTMLInputElement;
+
+      // Press Enter without typing
+      fireEvent.keyDown(input, { key: 'Enter' });
+
+      expect(createItem).not.toHaveBeenCalled();
+    });
+
+    it('does not create subtask if input is whitespace-only on Enter', () => {
+      const { container } = renderCardDetail();
+
+      const addBtn = container.querySelector('.detail-subtasks-header .btn-sm') as HTMLElement;
+      fireEvent.click(addBtn);
+
+      const input = container.querySelector('.subtask-add-input') as HTMLInputElement;
+      fireEvent.input(input, { target: { value: '   ' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+
+      expect(createItem).not.toHaveBeenCalled();
+    });
+  });
+
+  // AC5: Subtask creation cancels on Escape
+  describe('AC5: Subtask creation cancels on Escape', () => {
+    it('closes input without creating subtask when Escape is pressed', () => {
+      const { container } = renderCardDetail();
+
+      // Open inline input
+      const addBtn = container.querySelector('.detail-subtasks-header .btn-sm') as HTMLElement;
+      fireEvent.click(addBtn);
+
+      const input = container.querySelector('.subtask-add-input') as HTMLInputElement;
+      fireEvent.input(input, { target: { value: 'Some text' } });
+
+      // Press Escape
+      fireEvent.keyDown(input, { key: 'Escape' });
+
+      // Input should close
+      expect(container.querySelector('.subtask-add-input')).toBeNull();
+      // No subtask created
+      expect(createItem).not.toHaveBeenCalled();
+      // + Add button should return
+      expect(container.querySelector('.detail-subtasks-header .btn-sm')).not.toBeNull();
+    });
+
+    it('closes input without creating subtask on blur', () => {
+      const { container } = renderCardDetail();
+
+      const addBtn = container.querySelector('.detail-subtasks-header .btn-sm') as HTMLElement;
+      fireEvent.click(addBtn);
+
+      const input = container.querySelector('.subtask-add-input') as HTMLInputElement;
+      fireEvent.input(input, { target: { value: 'Some text' } });
+
+      // Blur the input (clicking away)
+      fireEvent.blur(input);
+
+      // Input should close
+      expect(container.querySelector('.subtask-add-input')).toBeNull();
+      expect(createItem).not.toHaveBeenCalled();
     });
   });
 });

--- a/frontend/src/components/board/card-detail.tsx
+++ b/frontend/src/components/board/card-detail.tsx
@@ -15,6 +15,11 @@ export function CardDetail() {
   const actor = user?.name || 'web';
   const children = childrenOfSelected.value;
 
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const [addingSubtask, setAddingSubtask] = useState(false);
+  const [subtaskTitle, setSubtaskTitle] = useState('');
+  const subtaskInputRef = useRef<HTMLInputElement>(null);
+
   const close = useCallback(() => {
     // Return focus to the triggering card element (AC5)
     const triggerId = selectedItemId.value;
@@ -36,19 +41,42 @@ export function CardDetail() {
   };
 
   const handleDelete = () => {
-    if (confirm('Delete this item and all sub-tasks?')) {
-      if (token) {
-        deleteItem(item.id, actor, token);
-        selectedItemId.value = null;
-      }
+    setConfirmingDelete(true);
+  };
+
+  const confirmDelete = () => {
+    if (token) {
+      deleteItem(item.id, actor, token);
+      selectedItemId.value = null;
     }
+    setConfirmingDelete(false);
+  };
+
+  const cancelDelete = () => {
+    setConfirmingDelete(false);
   };
 
   const handleAddSubtask = () => {
-    const title = prompt('Sub-task title:');
-    if (title && token) {
-      createItem({ title, parent_id: item.id, owner: item.owner }, actor, token);
+    setAddingSubtask(true);
+    setSubtaskTitle('');
+    // Focus the input after render
+    requestAnimationFrame(() => {
+      subtaskInputRef.current?.focus();
+    });
+  };
+
+  const submitSubtask = () => {
+    const trimmed = subtaskTitle.trim();
+    if (trimmed && token) {
+      createItem({ title: trimmed, parent_id: item.id, owner: item.owner }, actor, token);
     }
+    setAddingSubtask(false);
+    setSubtaskTitle('');
+  };
+
+  const cancelSubtask = () => {
+    setAddingSubtask(false);
+    setSubtaskTitle('');
   };
 
   const toggleChildStatus = (childId: string, currentStatus: ItemStatus) => {
@@ -162,7 +190,9 @@ export function CardDetail() {
           <div class="detail-subtasks">
             <div class="detail-subtasks-header">
               <label>Sub-tasks ({children.length})</label>
-              <button class="btn btn-sm" onClick={handleAddSubtask}>+ Add</button>
+              {!addingSubtask && (
+                <button class="btn btn-sm" onClick={handleAddSubtask}>+ Add</button>
+              )}
             </div>
             {children.length > 0 && (
               <ul class="subtask-list">
@@ -179,6 +209,23 @@ export function CardDetail() {
                 ))}
               </ul>
             )}
+            {addingSubtask && (
+              <div class="subtask-add-inline">
+                <input
+                  ref={subtaskInputRef}
+                  type="text"
+                  class="subtask-add-input"
+                  placeholder="Sub-task title..."
+                  value={subtaskTitle}
+                  onInput={(e) => setSubtaskTitle((e.target as HTMLInputElement).value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') { e.preventDefault(); submitSubtask(); }
+                    if (e.key === 'Escape') { e.stopPropagation(); cancelSubtask(); }
+                  }}
+                  onBlur={cancelSubtask}
+                />
+              </div>
+            )}
           </div>
 
           <div class="detail-meta">
@@ -191,7 +238,20 @@ export function CardDetail() {
         </div>
 
         <div class="detail-footer">
-          <button class="btn btn-danger" onClick={handleDelete}>Delete</button>
+          {confirmingDelete ? (
+            <div
+              class="delete-confirm-inline"
+              onKeyDown={(e) => {
+                if (e.key === 'Escape') { e.stopPropagation(); cancelDelete(); }
+              }}
+            >
+              <span class="delete-confirm-text">Are you sure?</span>
+              <button class="btn btn-ghost btn-sm" onClick={cancelDelete}>Cancel</button>
+              <button class="btn btn-danger btn-sm" onClick={confirmDelete}>Delete</button>
+            </div>
+          ) : (
+            <button class="btn btn-danger" onClick={handleDelete}>Delete</button>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -575,6 +575,39 @@ body {
   color: var(--color-text-secondary);
 }
 
+/* === Inline delete confirmation === */
+.delete-confirm-inline {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.delete-confirm-text {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--color-danger);
+}
+
+/* === Inline subtask add === */
+.subtask-add-inline {
+  margin-top: 4px;
+}
+
+.subtask-add-input {
+  width: 100%;
+  padding: 6px 8px;
+  border: 1px solid var(--color-primary);
+  border-radius: var(--radius-sm);
+  font-size: 14px;
+  font-family: inherit;
+  color: var(--color-text);
+  outline: none;
+}
+
+.subtask-add-input:focus {
+  box-shadow: var(--focus-ring);
+}
+
 .detail-meta {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- Replace browser `confirm()` for delete with inline "Are you sure? [Cancel] [Delete]" UI in the card detail footer
- Replace browser `prompt()` for subtask creation with inline text input supporting Enter to submit, Escape/blur to cancel
- Add CSS styles for the new inline components (delete confirmation and subtask input)
- Add 12 tests covering all 5 acceptance criteria from Issue #9

## Test plan
- [x] AC1: Clicking Delete shows inline confirmation (not browser confirm dialog)
- [x] AC2: Cancel button and Escape key dismiss the delete confirmation without deleting
- [x] AC3: Clicking "+ Add" shows inline text input (not browser prompt dialog)
- [x] AC4: Pressing Enter in the subtask input creates the subtask; empty/whitespace input is rejected
- [x] AC5: Pressing Escape or blurring the subtask input cancels without creating
- [x] All 46 frontend tests pass
- [x] All 12 apps-script tests pass
- [x] TypeScript compiles with no errors
- [x] Production build succeeds

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)