### PR TITLE
Add truncated description preview to cards

### DIFF
--- a/frontend/src/components/board/card.test.tsx
+++ b/frontend/src/components/board/card.test.tsx
@@ -241,4 +241,62 @@ describe('Card', () => {
       });
     });
   });
+
+  // Issue #12 — Description preview
+  describe('Description preview (Issue #12)', () => {
+    // AC1: Non-empty description shows truncated preview below title
+    describe('AC1: Description preview shows on card', () => {
+      it('renders a description preview when description is non-empty', () => {
+        const item = makeItem({ description: 'Pick up milk and eggs from the store' });
+        const { container } = render(<Card item={item} />);
+        const descEl = container.querySelector('.card-description');
+        expect(descEl).not.toBeNull();
+        expect(descEl!.textContent).toBe('Pick up milk and eggs from the store');
+      });
+
+      it('renders description below the title', () => {
+        const item = makeItem({ description: 'Some notes here' });
+        const { container } = render(<Card item={item} />);
+        const title = container.querySelector('.card-title');
+        const desc = container.querySelector('.card-description');
+        expect(title).not.toBeNull();
+        expect(desc).not.toBeNull();
+        // Description should be a sibling after title
+        expect(title!.nextElementSibling).toBe(desc);
+      });
+    });
+
+    // AC2: Long descriptions are truncated with ellipsis (CSS line-clamp)
+    describe('AC2: Long descriptions are truncated', () => {
+      it('applies CSS line-clamp class for long descriptions', () => {
+        const longDesc = 'This is a very long description that spans multiple lines. '.repeat(10);
+        const item = makeItem({ description: longDesc });
+        const { container } = render(<Card item={item} />);
+        const descEl = container.querySelector('.card-description');
+        expect(descEl).not.toBeNull();
+        expect(descEl!.classList.contains('card-description')).toBe(true);
+        // The CSS class card-description applies -webkit-line-clamp: 2
+      });
+    });
+
+    // AC3: Empty descriptions show nothing
+    describe('AC3: Empty descriptions show nothing', () => {
+      it('does not render description element when description is empty string', () => {
+        const item = makeItem({ description: '' });
+        const { container } = render(<Card item={item} />);
+        const descEl = container.querySelector('.card-description');
+        expect(descEl).toBeNull();
+      });
+
+      it('does not render description element when description is undefined-like', () => {
+        const item = makeItem({ description: '' });
+        const { container } = render(<Card item={item} />);
+        const descEl = container.querySelector('.card-description');
+        expect(descEl).toBeNull();
+        // Verify no empty space is left — card-meta should directly follow card-title
+        const title = container.querySelector('.card-title');
+        expect(title!.nextElementSibling!.classList.contains('card-meta')).toBe(true);
+      });
+    });
+  });
 });

--- a/frontend/src/components/board/card.tsx
+++ b/frontend/src/components/board/card.tsx
@@ -66,6 +66,10 @@ export function Card({ item, onMoveStatus }: Props) {
     >
       <div class="card-title">{item.title}</div>
 
+      {item.description && (
+        <div class="card-description">{item.description}</div>
+      )}
+
       <div class="card-meta">
         {item.owner ? (
           <span class="card-owner">{item.owner}</span>

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -319,6 +319,17 @@ body {
   font-weight: 600;
 }
 
+.card-description {
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  margin-bottom: 2px;
+}
+
 .card-labels {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- Add 2-line truncated description preview below card titles on the board
- Use CSS `line-clamp` for ellipsis truncation on long descriptions
- Empty descriptions render nothing (no placeholder or empty space)

Closes #12

## Test plan
- [x] AC1: Non-empty description shows preview below title in secondary text color
- [x] AC2: Long descriptions truncated with ellipsis via CSS line-clamp (max 2 lines)
- [x] AC3: Empty descriptions show nothing — no DOM element rendered
- [x] TypeScript type check passes
- [x] Production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)