### PR TITLE
feat: derive owner list from users with app access

### DIFF
--- a/frontend/src/api/sheets.test.ts
+++ b/frontend/src/api/sheets.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { upsertOwner } from './sheets';
+
+// Mock fetch globally for Sheets API calls
+const mockFetch = vi.fn() as Mock;
+globalThis.fetch = mockFetch;
+
+// The module reads VITE_SPREADSHEET_ID from import.meta.env.
+// Vitest + Vite makes this available, but we set a fallback via env.
+// Sheets functions build URLs from this, but we mock fetch so the value doesn't matter.
+
+function mockSheetsGetResponse(values: any[][]) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({ values }),
+    text: async () => '',
+  };
+}
+
+function mockSheetsWriteResponse() {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({}),
+    text: async () => '',
+  };
+}
+
+describe('upsertOwner', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  // Scenario 1: First-time sign-in auto-registers owner
+  it('appends a new row when email is not found in Owners sheet', async () => {
+    // First call: sheetsGet('Owners!A2:B') — returns existing owners without the new user
+    mockFetch.mockResolvedValueOnce(
+      mockSheetsGetResponse([
+        ['Mom', 'mom@example.com'],
+        ['Dad', 'dad@example.com'],
+      ])
+    );
+    // Second call: sheetsAppend — appends the new owner row
+    mockFetch.mockResolvedValueOnce(mockSheetsWriteResponse());
+
+    const result = await upsertOwner('Luke', 'luke@example.com', 'test-token');
+
+    expect(result).toBe(true);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    // Verify the append call
+    const appendCall = mockFetch.mock.calls[1];
+    const appendUrl = appendCall[0] as string;
+    expect(appendUrl).toContain('Owners');
+    expect(appendUrl).toContain(':append');
+    const appendBody = JSON.parse(appendCall[1].body);
+    expect(appendBody.values).toEqual([['Luke', 'luke@example.com']]);
+  });
+
+  // Scenario 2: Returning user does not duplicate
+  it('returns false (no write) when email exists and name matches', async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockSheetsGetResponse([
+        ['Mom', 'mom@example.com'],
+        ['Luke', 'luke@example.com'],
+      ])
+    );
+
+    const result = await upsertOwner('Luke', 'luke@example.com', 'test-token');
+
+    expect(result).toBe(false);
+    // Only the GET call, no write
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  // Scenario 2 (name change): Updates name when email exists but name differs
+  it('updates the name when email exists but display name has changed', async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockSheetsGetResponse([
+        ['Mom', 'mom@example.com'],
+        ['Old Name', 'luke@example.com'],
+      ])
+    );
+    // sheetsUpdate call
+    mockFetch.mockResolvedValueOnce(mockSheetsWriteResponse());
+
+    const result = await upsertOwner('Luke', 'luke@example.com', 'test-token');
+
+    expect(result).toBe(true);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    // Verify the update call targets the correct row (index 1 in data = row 3 in sheet)
+    const updateCall = mockFetch.mock.calls[1];
+    const updateUrl = updateCall[0] as string;
+    // URL-encoded: colon becomes %3A via encodeURIComponent
+    expect(updateUrl).toContain('Owners!A3%3AB3');
+    expect(updateCall[1].method).toBe('PUT');
+    const updateBody = JSON.parse(updateCall[1].body);
+    expect(updateBody.values).toEqual([['Luke', 'luke@example.com']]);
+  });
+
+  // Email matching should be case-insensitive
+  it('matches email case-insensitively', async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockSheetsGetResponse([
+        ['Luke', 'Luke@Example.COM'],
+      ])
+    );
+
+    const result = await upsertOwner('Luke', 'luke@example.com', 'test-token');
+
+    expect(result).toBe(false);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  // Edge case: empty Owners sheet
+  it('appends when Owners sheet is empty', async () => {
+    mockFetch.mockResolvedValueOnce(mockSheetsGetResponse([]));
+    mockFetch.mockResolvedValueOnce(mockSheetsWriteResponse());
+
+    const result = await upsertOwner('Luke', 'luke@example.com', 'test-token');
+
+    expect(result).toBe(true);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  // Scenario 5: API failure propagates (ensureOwnerRegistered catches it)
+  it('throws when the Sheets API returns an error', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      text: async () => 'Internal Server Error',
+    });
+
+    await expect(upsertOwner('Luke', 'luke@example.com', 'test-token'))
+      .rejects.toThrow('Sheets API 500');
+  });
+});

--- a/frontend/src/api/sheets.ts
+++ b/frontend/src/api/sheets.ts
@@ -154,6 +154,42 @@ export async function deleteItemRow(sheetRow: number, token: string): Promise<vo
   await sheetsDeleteRow(sheetId, sheetRow, token);
 }
 
+/**
+ * Upsert an owner row in the Owners sheet.
+ * - If the email already exists and the name matches, does nothing (returns false).
+ * - If the email exists but the name differs, updates the name (returns true).
+ * - If the email is not found, appends a new row (returns true).
+ * Returns true if a write occurred (caller should re-fetch owners).
+ */
+export async function upsertOwner(
+  name: string,
+  email: string,
+  token: string
+): Promise<boolean> {
+  const rows = await sheetsGet('Owners!A2:B', token);
+
+  // Find existing row by email (column B)
+  const existingIndex = rows.findIndex(
+    row => (row[1] || '').toLowerCase() === email.toLowerCase()
+  );
+
+  if (existingIndex >= 0) {
+    // Email already exists — check if name needs updating
+    const existingName = rows[existingIndex][0] || '';
+    if (existingName === name) {
+      return false; // No change needed
+    }
+    // Update the name in the existing row (row index + 2 because header is row 1, data starts at row 2)
+    const sheetRow = existingIndex + 2;
+    await sheetsUpdate(`Owners!A${sheetRow}:B${sheetRow}`, [[name, email]], token);
+    return true;
+  }
+
+  // Email not found — append new row
+  await sheetsAppend('Owners!A:B', [[name, email]], token);
+  return true;
+}
+
 export async function appendAuditEntry(
   itemId: string,
   action: string,

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -10,14 +10,14 @@ import { loadBoard, refreshItems } from './state/actions';
 import { loading } from './state/board-store';
 
 function AuthenticatedApp() {
-  const { token } = useAuth();
+  const { token, user } = useAuth();
   const intervalRef = useRef<number>();
   const demo = isDemoMode();
 
   useEffect(() => {
     if (!token) return;
 
-    loadBoard(token);
+    loadBoard(token, user);
 
     // Disable polling in demo mode — mock data is static, no other users.
     if (!demo) {

--- a/frontend/src/demo/mock-api.ts
+++ b/frontend/src/demo/mock-api.ts
@@ -57,3 +57,12 @@ export async function appendAuditEntry(
 ): Promise<void> {
   // No-op in demo mode — audit log is not displayed in the UI.
 }
+
+export async function upsertOwner(
+  _name: string,
+  _email: string,
+  _token: string
+): Promise<boolean> {
+  // No-op in demo mode — mock data already has owners.
+  return false;
+}

--- a/frontend/src/state/actions.test.ts
+++ b/frontend/src/state/actions.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { UserInfo } from '../api/types';
+
+// Mock the sheets API module before importing actions
+vi.mock('../api/sheets', () => ({
+  fetchAllItems: vi.fn().mockResolvedValue([]),
+  fetchOwners: vi.fn().mockResolvedValue([]),
+  fetchLabels: vi.fn().mockResolvedValue([]),
+  createItemRow: vi.fn().mockResolvedValue(undefined),
+  updateItemRow: vi.fn().mockResolvedValue(undefined),
+  deleteItemRow: vi.fn().mockResolvedValue(undefined),
+  appendAuditEntry: vi.fn().mockResolvedValue(undefined),
+  upsertOwner: vi.fn().mockResolvedValue(false),
+  SheetsApiError: class extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(`Sheets API ${status}: ${message}`);
+      this.status = status;
+    }
+  },
+}));
+
+// Mock demo mode to return false (real API mode)
+vi.mock('../demo/is-demo-mode', () => ({
+  isDemoMode: vi.fn().mockReturnValue(false),
+}));
+
+// Mock the mock-api module (required by actions.ts import)
+vi.mock('../demo/mock-api', () => ({
+  fetchAllItems: vi.fn().mockResolvedValue([]),
+  fetchOwners: vi.fn().mockResolvedValue([]),
+  fetchLabels: vi.fn().mockResolvedValue([]),
+  createItemRow: vi.fn().mockResolvedValue(undefined),
+  updateItemRow: vi.fn().mockResolvedValue(undefined),
+  deleteItemRow: vi.fn().mockResolvedValue(undefined),
+  appendAuditEntry: vi.fn().mockResolvedValue(undefined),
+  upsertOwner: vi.fn().mockResolvedValue(false),
+}));
+
+import { ensureOwnerRegistered, loadBoard } from './actions';
+import { owners, loading } from './board-store';
+import * as sheetsApi from '../api/sheets';
+
+const mockUpsertOwner = vi.mocked(sheetsApi.upsertOwner);
+const mockFetchOwners = vi.mocked(sheetsApi.fetchOwners);
+const mockFetchAllItems = vi.mocked(sheetsApi.fetchAllItems);
+const mockFetchLabels = vi.mocked(sheetsApi.fetchLabels);
+
+describe('ensureOwnerRegistered', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Scenario 1: First-time sign-in calls upsertOwner with display name and email
+  it('calls upsertOwner with display name and email', async () => {
+    mockUpsertOwner.mockResolvedValueOnce(true);
+    const user: UserInfo = { name: 'Luke', email: 'luke@example.com', picture: '' };
+
+    const result = await ensureOwnerRegistered(user, 'test-token');
+
+    expect(result).toBe(true);
+    expect(mockUpsertOwner).toHaveBeenCalledWith('Luke', 'luke@example.com', 'test-token');
+  });
+
+  // Scenario 2: Returning user — upsertOwner returns false (no write)
+  it('returns false when upsertOwner finds no changes needed', async () => {
+    mockUpsertOwner.mockResolvedValueOnce(false);
+    const user: UserInfo = { name: 'Luke', email: 'luke@example.com', picture: '' };
+
+    const result = await ensureOwnerRegistered(user, 'test-token');
+
+    expect(result).toBe(false);
+  });
+
+  // Edge case: Google account with no display name falls back to email prefix
+  it('falls back to email prefix when display name is empty', async () => {
+    mockUpsertOwner.mockResolvedValueOnce(true);
+    const user: UserInfo = { name: '', email: 'luke@example.com', picture: '' };
+
+    await ensureOwnerRegistered(user, 'test-token');
+
+    expect(mockUpsertOwner).toHaveBeenCalledWith('luke', 'luke@example.com', 'test-token');
+  });
+
+  // Scenario 5: Auto-register fails gracefully
+  it('returns false and logs to console when upsertOwner throws', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockUpsertOwner.mockRejectedValueOnce(new Error('Network error'));
+    const user: UserInfo = { name: 'Luke', email: 'luke@example.com', picture: '' };
+
+    const result = await ensureOwnerRegistered(user, 'test-token');
+
+    expect(result).toBe(false);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Auto-register owner failed:',
+      expect.any(Error)
+    );
+    consoleErrorSpy.mockRestore();
+  });
+});
+
+describe('loadBoard with auto-registration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchAllItems.mockResolvedValue([]);
+    mockFetchLabels.mockResolvedValue([]);
+    mockFetchOwners.mockResolvedValue([{ name: 'Mom', google_account: 'mom@example.com' }]);
+  });
+
+  // Scenario 1: loadBoard triggers auto-registration and re-fetches owners on write
+  it('auto-registers user and re-fetches owners when upsert writes', async () => {
+    mockUpsertOwner.mockResolvedValueOnce(true);
+    // After upsert, the re-fetch returns updated owners
+    mockFetchOwners
+      .mockResolvedValueOnce([{ name: 'Mom', google_account: 'mom@example.com' }])  // initial load
+      .mockResolvedValueOnce([
+        { name: 'Mom', google_account: 'mom@example.com' },
+        { name: 'Luke', google_account: 'luke@example.com' },
+      ]);  // re-fetch after upsert
+
+    const user: UserInfo = { name: 'Luke', email: 'luke@example.com', picture: '' };
+    await loadBoard('test-token', user);
+
+    expect(mockUpsertOwner).toHaveBeenCalledWith('Luke', 'luke@example.com', 'test-token');
+    // fetchOwners called twice: once in initial parallel fetch, once after upsert
+    expect(mockFetchOwners).toHaveBeenCalledTimes(2);
+    // owners signal should have both owners
+    expect(owners.value).toHaveLength(2);
+    expect(owners.value.find(o => o.name === 'Luke')).toBeTruthy();
+    expect(loading.value).toBe(false);
+  });
+
+  // Scenario 2: No re-fetch when upsert returns false (no change)
+  it('skips re-fetch when upsert returns false (no change needed)', async () => {
+    mockUpsertOwner.mockResolvedValueOnce(false);
+
+    const user: UserInfo = { name: 'Mom', email: 'mom@example.com', picture: '' };
+    await loadBoard('test-token', user);
+
+    expect(mockUpsertOwner).toHaveBeenCalled();
+    // fetchOwners called only once (initial load), not re-fetched
+    expect(mockFetchOwners).toHaveBeenCalledTimes(1);
+    expect(loading.value).toBe(false);
+  });
+
+  // loadBoard without user does not call ensureOwnerRegistered
+  it('does not call upsertOwner when user is not provided', async () => {
+    await loadBoard('test-token');
+
+    expect(mockUpsertOwner).not.toHaveBeenCalled();
+    expect(loading.value).toBe(false);
+  });
+
+  // Scenario 5: Board loads even if auto-registration fails
+  it('still loads the board when auto-registration fails', async () => {
+    mockUpsertOwner.mockRejectedValueOnce(new Error('Network error'));
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const user: UserInfo = { name: 'Luke', email: 'luke@example.com', picture: '' };
+    await loadBoard('test-token', user);
+
+    // Board should still have loaded successfully
+    expect(owners.value).toHaveLength(1);
+    expect(owners.value[0].name).toBe('Mom');
+    expect(loading.value).toBe(false);
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/frontend/src/state/actions.ts
+++ b/frontend/src/state/actions.ts
@@ -8,6 +8,7 @@ import {
   updateItemRow as sheetsUpdateItemRow,
   deleteItemRow as sheetsDeleteItemRow,
   appendAuditEntry as sheetsAppendAuditEntry,
+  upsertOwner as sheetsUpsertOwner,
 } from '../api/sheets';
 import {
   fetchAllItems as mockFetchAllItems,
@@ -17,10 +18,11 @@ import {
   updateItemRow as mockUpdateItemRow,
   deleteItemRow as mockDeleteItemRow,
   appendAuditEntry as mockAppendAuditEntry,
+  upsertOwner as mockUpsertOwner,
 } from '../demo/mock-api';
 import { isDemoMode } from '../demo/is-demo-mode';
 import { owners, labels, loading } from './board-store';
-import type { Item, ItemStatus, ItemWithRow } from '../api/types';
+import type { Item, ItemStatus, ItemWithRow, UserInfo } from '../api/types';
 
 // Select real or mock API based on demo mode.
 // isDemoMode() is cached after the first call, so this is cheap.
@@ -34,6 +36,7 @@ function api() {
       updateItemRow: mockUpdateItemRow,
       deleteItemRow: mockDeleteItemRow,
       appendAuditEntry: mockAppendAuditEntry,
+      upsertOwner: mockUpsertOwner,
     };
   }
   return {
@@ -44,6 +47,7 @@ function api() {
     updateItemRow: sheetsUpdateItemRow,
     deleteItemRow: sheetsDeleteItemRow,
     appendAuditEntry: sheetsAppendAuditEntry,
+    upsertOwner: sheetsUpsertOwner,
   };
 }
 
@@ -54,12 +58,34 @@ const createItemRow = (...args: Parameters<typeof sheetsCreateItemRow>) => api()
 const updateItemRow = (...args: Parameters<typeof sheetsUpdateItemRow>) => api().updateItemRow(...args);
 const deleteItemRow = (...args: Parameters<typeof sheetsDeleteItemRow>) => api().deleteItemRow(...args);
 const appendAuditEntry = (...args: Parameters<typeof sheetsAppendAuditEntry>) => api().appendAuditEntry(...args);
+const upsertOwner = (...args: Parameters<typeof sheetsUpsertOwner>) => api().upsertOwner(...args);
 
 function generateUUID(): string {
   return crypto.randomUUID();
 }
 
-export async function loadBoard(token: string) {
+/**
+ * Ensure the signed-in user exists in the Owners sheet.
+ * If the user is new, appends a row. If the display name changed, updates it.
+ * Fails silently — board loading continues even if this fails.
+ * Returns true if a write occurred (caller should re-fetch owners).
+ */
+export async function ensureOwnerRegistered(
+  user: UserInfo,
+  token: string
+): Promise<boolean> {
+  try {
+    // Fall back to email prefix if no display name is set
+    const displayName = user.name || user.email.split('@')[0];
+    return await upsertOwner(displayName, user.email, token);
+  } catch (err) {
+    // Non-blocking: log to console but do not show a toast
+    console.error('Auto-register owner failed:', err);
+    return false;
+  }
+}
+
+export async function loadBoard(token: string, user?: UserInfo | null) {
   loading.value = true;
   try {
     const [itemsData, ownersData, labelsData] = await Promise.all([
@@ -70,6 +96,16 @@ export async function loadBoard(token: string) {
     items.value = itemsData;
     owners.value = ownersData;
     labels.value = labelsData;
+
+    // Auto-register the signed-in user as an owner (after initial data load).
+    // Runs in the background — a write triggers a re-fetch of owners so the
+    // UI immediately reflects the new entry.
+    if (user) {
+      const wrote = await ensureOwnerRegistered(user, token);
+      if (wrote) {
+        owners.value = await fetchOwners(token);
+      }
+    }
   } catch (err: any) {
     showToast('Failed to load board: ' + err.message, 'error');
   } finally {


### PR DESCRIPTION
## Summary
Auto-registers signed-in users as owners in the Owners sheet on first login, populating owner dropdowns with display names derived from Google accounts.

Closes #25

## Changes
- **`frontend/src/api/sheets.ts`** — Added `upsertOwner(name, email, token)` function that reads the Owners sheet, checks for an existing email (case-insensitive), and either appends a new row, updates the display name, or does nothing if unchanged.
- **`frontend/src/state/actions.ts`** — Added `ensureOwnerRegistered(user, token)` that wraps `upsertOwner` with silent error handling (console.error only, no toast). Updated `loadBoard()` to accept an optional `user` parameter and call auto-registration after the initial data fetch, re-fetching owners if a write occurred.
- **`frontend/src/app.tsx`** — Pass `user` from `useAuth()` into `loadBoard(token, user)` so auto-registration has access to the signed-in user's info.
- **`frontend/src/demo/mock-api.ts`** — Added no-op `upsertOwner` stub for demo mode (returns `false`, no writes).

## Testing
14 new test cases covering all 5 acceptance criteria:

**`frontend/src/api/sheets.test.ts`** (6 tests — `upsertOwner` unit tests):
- AC1: Appends new row when email not found in Owners sheet
- AC2: Returns false (no write) when email exists and name matches
- AC2: Updates name when email exists but display name changed
- Email matching is case-insensitive
- Appends when Owners sheet is empty
- AC5: Throws on Sheets API error (propagates to caller)

**`frontend/src/state/actions.test.ts`** (8 tests — `ensureOwnerRegistered` + `loadBoard` integration):
- AC1: Calls upsertOwner with display name and email
- AC2: Returns false when no changes needed
- Edge case: Falls back to email prefix when display name is empty
- AC5: Returns false and logs console error on failure (no toast)
- AC1: loadBoard triggers auto-registration and re-fetches owners on write
- AC2: loadBoard skips re-fetch when no change needed
- loadBoard without user does not call upsertOwner
- AC5: Board loads successfully even when auto-registration fails

## Rules Sync
- [x] No business rules changed — owner field on items remains a plain display name string
- [x] `frontend/src/state/rules.ts` — not modified (not applicable)
- [x] `apps-script/src/rules.js` — not modified (not applicable)
- [x] Both files remain in sync