### PR TITLE
feat: track which user created each item

### DIFF
--- a/apps-script/src/items.js
+++ b/apps-script/src/items.js
@@ -65,6 +65,7 @@ function createItem(data, actor) {
     updated_at: now,
     completed_at: status === 'Done' ? now : '',
     sort_order: data.sort_order != null ? data.sort_order : getNextSortOrder(allItems, status),
+    created_by: data.created_by || actor,
   };
 
   if (item.status === 'In Progress' && !item.owner) {

--- a/apps-script/src/types.js
+++ b/apps-script/src/types.js
@@ -16,8 +16,9 @@ var COL = {
   UPDATED_AT: 10,
   COMPLETED_AT: 11,
   SORT_ORDER: 12,
+  CREATED_BY: 13,
 };
 
-var ITEM_COLUMN_COUNT = 13;
+var ITEM_COLUMN_COUNT = 14;
 
 var VALID_STATUSES = ['To Do', 'In Progress', 'Done'];

--- a/apps-script/src/utils.js
+++ b/apps-script/src/utils.js
@@ -39,6 +39,7 @@ function rowToItem(row) {
     updated_at: row[COL.UPDATED_AT] ? String(row[COL.UPDATED_AT]) : '',
     completed_at: row[COL.COMPLETED_AT] ? String(row[COL.COMPLETED_AT]) : '',
     sort_order: Number(row[COL.SORT_ORDER]) || 0,
+    created_by: row[COL.CREATED_BY] || '',
   };
 }
 
@@ -57,6 +58,7 @@ function itemToRow(item) {
     item.updated_at,
     item.completed_at,
     item.sort_order,
+    item.created_by,
   ];
 }
 

--- a/apps-script/tests/rules.test.ts
+++ b/apps-script/tests/rules.test.ts
@@ -20,6 +20,7 @@ interface Item {
   updated_at: string;
   completed_at: string;
   sort_order: number;
+  created_by: string;
 }
 
 interface ValidationResult {
@@ -83,6 +84,7 @@ function makeItem(overrides: Partial<Item> = {}): Item {
     updated_at: '2025-01-01T00:00:00.000Z',
     completed_at: '',
     sort_order: 1,
+    created_by: '',
     ...overrides,
   };
 }

--- a/frontend/src/api/sheets.ts
+++ b/frontend/src/api/sheets.ts
@@ -94,6 +94,7 @@ function rowToItem(row: any[]): Item {
     updated_at: row[10] || '',
     completed_at: row[11] || '',
     sort_order: Number(row[12]) || 0,
+    created_by: row[13] || '',
   };
 }
 
@@ -102,14 +103,14 @@ function itemToRow(item: Item): any[] {
     item.id, item.title, item.description, item.status,
     item.owner, item.due_date, item.scheduled_date, item.labels,
     item.parent_id, item.created_at, item.updated_at, item.completed_at,
-    item.sort_order,
+    item.sort_order, item.created_by,
   ];
 }
 
 // --- Public API ---
 
 export async function fetchAllItems(token: string): Promise<ItemWithRow[]> {
-  const rows = await sheetsGet('Items!A2:M', token);
+  const rows = await sheetsGet('Items!A2:N', token);
   return rows.map((row, i) => ({
     ...rowToItem(row),
     sheetRow: i + 2, // 1-based, header is row 1
@@ -133,11 +134,11 @@ export async function fetchLabels(token: string): Promise<Label[]> {
 }
 
 export async function createItemRow(item: Item, token: string): Promise<void> {
-  await sheetsAppend('Items!A:M', [itemToRow(item)], token);
+  await sheetsAppend('Items!A:N', [itemToRow(item)], token);
 }
 
 export async function updateItemRow(sheetRow: number, item: Item, token: string): Promise<void> {
-  await sheetsUpdate(`Items!A${sheetRow}:M${sheetRow}`, [itemToRow(item)], token);
+  await sheetsUpdate(`Items!A${sheetRow}:N${sheetRow}`, [itemToRow(item)], token);
 }
 
 export async function deleteItemRow(sheetRow: number, token: string): Promise<void> {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -17,6 +17,7 @@ export interface Item {
   updated_at: string;
   completed_at: string;
   sort_order: number;
+  created_by: string;
 }
 
 export interface ItemWithRow extends Item {

--- a/frontend/src/components/board/card-detail-aria.test.tsx
+++ b/frontend/src/components/board/card-detail-aria.test.tsx
@@ -32,6 +32,7 @@ vi.mock('../../state/board-store', () => ({
         updated_at: '2026-01-01T00:00:00Z',
         completed_at: '',
         sort_order: 1,
+        created_by: 'luke@example.com',
         sheetRow: 2,
       };
     },
@@ -53,6 +54,7 @@ vi.mock('../../state/board-store', () => ({
           updated_at: '2026-01-01T00:00:00Z',
           completed_at: '',
           sort_order: 1,
+          created_by: 'luke@example.com',
           sheetRow: 3,
         },
         {
@@ -69,6 +71,7 @@ vi.mock('../../state/board-store', () => ({
           updated_at: '2026-01-01T00:00:00Z',
           completed_at: '2026-01-02T00:00:00Z',
           sort_order: 2,
+          created_by: 'luke@example.com',
           sheetRow: 4,
         },
       ];

--- a/frontend/src/components/board/card-detail.test.tsx
+++ b/frontend/src/components/board/card-detail.test.tsx
@@ -34,6 +34,7 @@ vi.mock('../../state/board-store', () => ({
         updated_at: '2026-01-01T00:00:00Z',
         completed_at: '',
         sort_order: 1,
+        created_by: 'luke@example.com',
         sheetRow: 2,
       };
     },
@@ -463,7 +464,7 @@ describe('CardDetail inline dialogs (Issue #9)', () => {
       fireEvent.keyDown(input, { key: 'Enter' });
 
       expect(createItem).toHaveBeenCalledWith(
-        { title: 'New subtask', parent_id: 'detail-test-1', owner: 'Luke' },
+        { title: 'New subtask', parent_id: 'detail-test-1', owner: 'Luke', created_by: 'luke@example.com' },
         'Luke',
         'test-token'
       );
@@ -539,6 +540,44 @@ describe('CardDetail inline dialogs (Issue #9)', () => {
       // Input should close
       expect(container.querySelector('.subtask-add-input')).toBeNull();
       expect(createItem).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('CardDetail created_by display (Issue #23)', () => {
+  beforeEach(() => {
+    mockSelectedItemId = 'detail-test-1';
+  });
+
+  // AC4: Creator displayed in card detail view
+  describe('AC4: Creator displayed in metadata section', () => {
+    it('shows "Created by" line in the detail metadata section', () => {
+      const { container } = renderCardDetail();
+      const metaSection = container.querySelector('.detail-meta');
+      expect(metaSection).not.toBeNull();
+      const smalls = metaSection!.querySelectorAll('small');
+      const createdByLine = Array.from(smalls).find(s => s.textContent?.startsWith('Created by:'));
+      expect(createdByLine).not.toBeNull();
+    });
+
+    it('resolves email to display name when email matches a known owner', () => {
+      // The mock item has created_by: 'luke@example.com' and
+      // owners has { name: 'Luke', google_account: 'luke@example.com' }
+      const { container } = renderCardDetail();
+      const metaSection = container.querySelector('.detail-meta');
+      const smalls = metaSection!.querySelectorAll('small');
+      const createdByLine = Array.from(smalls).find(s => s.textContent?.startsWith('Created by:'));
+      expect(createdByLine!.textContent).toBe('Created by: Luke');
+    });
+  });
+
+  // AC5: Creator field is read-only
+  describe('AC5: Creator field is read-only', () => {
+    it('created_by line is not editable (no input/select in metadata)', () => {
+      const { container } = renderCardDetail();
+      const metaSection = container.querySelector('.detail-meta');
+      const inputs = metaSection!.querySelectorAll('input, select, textarea');
+      expect(inputs.length).toBe(0);
     });
   });
 });

--- a/frontend/src/components/board/card-detail.tsx
+++ b/frontend/src/components/board/card-detail.tsx
@@ -75,7 +75,7 @@ export function CardDetail() {
   const submitSubtask = () => {
     const trimmed = subtaskTitle.trim();
     if (trimmed && token) {
-      createItem({ title: trimmed, parent_id: item.id, owner: item.owner }, actor, token);
+      createItem({ title: trimmed, parent_id: item.id, owner: item.owner, created_by: user?.email || '' }, actor, token);
     }
     setAddingSubtask(false);
     setSubtaskTitle('');
@@ -261,6 +261,12 @@ export function CardDetail() {
           </div>
 
           <div class="detail-meta">
+            {item.created_by && (
+              <small>Created by: {owners.value.find(o => o.google_account === item.created_by)?.name || item.created_by}</small>
+            )}
+            {!item.created_by && (
+              <small>Created by: Unknown</small>
+            )}
             <small>Created: {new Date(item.created_at).toLocaleString()}</small>
             <small>Updated: {new Date(item.updated_at).toLocaleString()}</small>
             {item.completed_at && (

--- a/frontend/src/components/board/card-mobile.test.tsx
+++ b/frontend/src/components/board/card-mobile.test.tsx
@@ -26,6 +26,7 @@ function makeItem(overrides: Partial<ItemWithRow> = {}): ItemWithRow {
     updated_at: '2026-01-01T00:00:00Z',
     completed_at: '',
     sort_order: 1,
+    created_by: '',
     sheetRow: 2,
     ...overrides,
   };

--- a/frontend/src/components/board/card.test.tsx
+++ b/frontend/src/components/board/card.test.tsx
@@ -26,6 +26,7 @@ function makeItem(overrides: Partial<ItemWithRow> = {}): ItemWithRow {
     updated_at: '2026-01-01T00:00:00Z',
     completed_at: '',
     sort_order: 1,
+    created_by: '',
     sheetRow: 2,
     ...overrides,
   };

--- a/frontend/src/components/board/column.test.tsx
+++ b/frontend/src/components/board/column.test.tsx
@@ -29,6 +29,7 @@ function makeItem(overrides: Partial<ItemWithRow> = {}): ItemWithRow {
     updated_at: '2026-01-01T00:00:00Z',
     completed_at: '',
     sort_order: 1,
+    created_by: '',
     sheetRow: 2,
     ...overrides,
   };

--- a/frontend/src/components/board/kanban-board.test.tsx
+++ b/frontend/src/components/board/kanban-board.test.tsx
@@ -92,7 +92,7 @@ describe('KanbanBoard empty/welcome state (Issue #11)', () => {
         id: '1', title: 'Task', description: '', status: 'To Do',
         owner: '', due_date: '', scheduled_date: '', labels: '',
         parent_id: '', created_at: '', updated_at: '', completed_at: '',
-        sort_order: 1, sheetRow: 2,
+        sort_order: 1, created_by: '', sheetRow: 2,
       }];
       const { container } = renderBoard();
       const welcome = container.querySelector('[data-testid="board-welcome"]');
@@ -114,7 +114,7 @@ describe('KanbanBoard empty/welcome state (Issue #11)', () => {
         id: '1', title: 'Task', description: '', status: 'To Do',
         owner: '', due_date: '', scheduled_date: '', labels: '',
         parent_id: '', created_at: '', updated_at: '', completed_at: '',
-        sort_order: 1, sheetRow: 2,
+        sort_order: 1, created_by: '', sheetRow: 2,
       }];
       const { container } = renderBoard();
       // Board should show columns, not welcome

--- a/frontend/src/components/board/list-view.test.tsx
+++ b/frontend/src/components/board/list-view.test.tsx
@@ -40,6 +40,7 @@ function makeItem(overrides: Partial<ItemWithRow> = {}): ItemWithRow {
     updated_at: '2026-01-01T00:00:00Z',
     completed_at: '',
     sort_order: 1,
+    created_by: '',
     sheetRow: 2,
     ...overrides,
   };

--- a/frontend/src/components/board/view-toggle.test.tsx
+++ b/frontend/src/components/board/view-toggle.test.tsx
@@ -91,7 +91,7 @@ describe('View Toggle (Issue #13)', () => {
         id: '1', title: 'Task A', description: '', status: 'To Do',
         owner: '', due_date: '', scheduled_date: '', labels: '',
         parent_id: '', created_at: '', updated_at: '', completed_at: '',
-        sort_order: 1, sheetRow: 2,
+        sort_order: 1, created_by: '', sheetRow: 2,
       },
     ];
   });

--- a/frontend/src/components/forms/create-item-modal.tsx
+++ b/frontend/src/components/forms/create-item-modal.tsx
@@ -25,6 +25,7 @@ export function CreateItemModal() {
         owner,
         due_date: dueDate,
         labels: selectedLabels.join(', '),
+        created_by: user?.email || '',
       },
       user?.name || 'web',
       token

--- a/frontend/src/demo/mock-api.test.ts
+++ b/frontend/src/demo/mock-api.test.ts
@@ -51,6 +51,7 @@ describe('Mock API layer (AC5)', () => {
       updated_at: new Date().toISOString(),
       completed_at: '',
       sort_order: 100,
+      created_by: 'test@example.com',
     };
     await createItemRow(newItem, 'demo-token');
     const after = await fetchAllItems('demo-token');
@@ -105,7 +106,7 @@ describe('Mock API layer (AC5)', () => {
     const newItem: Item = {
       id: 'test-http', title: 'Test', description: '', status: 'To Do',
       owner: '', due_date: '', scheduled_date: '', labels: '', parent_id: '',
-      created_at: '', updated_at: '', completed_at: '', sort_order: 0,
+      created_at: '', updated_at: '', completed_at: '', sort_order: 0, created_by: '',
     };
     await createItemRow(newItem, 'demo-token');
     await updateItemRow(2, newItem, 'demo-token');

--- a/frontend/src/demo/mock-data.test.ts
+++ b/frontend/src/demo/mock-data.test.ts
@@ -64,6 +64,14 @@ describe('Mock data coverage (AC4)', () => {
     expect(colors.size).toBe(MOCK_LABELS.length);
   });
 
+  it('every item has a plausible created_by email matching an owner google_account', () => {
+    for (const item of MOCK_ITEMS) {
+      expect(item.created_by).toBeTruthy();
+      const matchingOwner = MOCK_OWNERS.find(o => o.google_account === item.created_by);
+      expect(matchingOwner).toBeTruthy();
+    }
+  });
+
   it('data is static/deterministic (same values every invocation)', () => {
     // Re-import to verify same reference data
     const items1 = MOCK_ITEMS;

--- a/frontend/src/demo/mock-data.ts
+++ b/frontend/src/demo/mock-data.ts
@@ -53,6 +53,7 @@ export const MOCK_ITEMS: ItemWithRow[] = [
     updated_at: daysAgo(1),
     completed_at: '',
     sort_order: 1,
+    created_by: 'mom@family.com',
     sheetRow: 2,
   },
   // Subtask 1a: Buy vegetables — Done
@@ -70,6 +71,7 @@ export const MOCK_ITEMS: ItemWithRow[] = [
     updated_at: daysAgo(2),
     completed_at: daysAgo(2),
     sort_order: 1,
+    created_by: 'mom@family.com',
     sheetRow: 3,
   },
   // Subtask 1b: Buy cleaning supplies — Done
@@ -87,6 +89,7 @@ export const MOCK_ITEMS: ItemWithRow[] = [
     updated_at: daysAgo(2),
     completed_at: daysAgo(2),
     sort_order: 2,
+    created_by: 'mom@family.com',
     sheetRow: 4,
   },
   // Subtask 1c: Pick up prescription — To Do, assigned to Dad
@@ -104,6 +107,7 @@ export const MOCK_ITEMS: ItemWithRow[] = [
     updated_at: daysAgo(3),
     completed_at: '',
     sort_order: 3,
+    created_by: 'mom@family.com',
     sheetRow: 5,
   },
 
@@ -122,6 +126,7 @@ export const MOCK_ITEMS: ItemWithRow[] = [
     updated_at: daysAgo(1),
     completed_at: '',
     sort_order: 1,
+    created_by: 'dad@family.com',
     sheetRow: 6,
   },
 
@@ -140,6 +145,7 @@ export const MOCK_ITEMS: ItemWithRow[] = [
     updated_at: daysAgo(0),
     completed_at: '',
     sort_order: 2,
+    created_by: 'kiddo@family.com',
     sheetRow: 7,
   },
 
@@ -158,6 +164,7 @@ export const MOCK_ITEMS: ItemWithRow[] = [
     updated_at: daysAgo(7),
     completed_at: '',
     sort_order: 2,
+    created_by: 'mom@family.com',
     sheetRow: 8,
   },
 
@@ -176,6 +183,7 @@ export const MOCK_ITEMS: ItemWithRow[] = [
     updated_at: daysAgo(7),
     completed_at: daysAgo(7),
     sort_order: 1,
+    created_by: 'dad@family.com',
     sheetRow: 9,
   },
 
@@ -194,6 +202,7 @@ export const MOCK_ITEMS: ItemWithRow[] = [
     updated_at: daysAgo(2),
     completed_at: '',
     sort_order: 3,
+    created_by: 'mom@family.com',
     sheetRow: 10,
   },
 
@@ -212,6 +221,7 @@ export const MOCK_ITEMS: ItemWithRow[] = [
     updated_at: daysAgo(3),
     completed_at: '',
     sort_order: 4,
+    created_by: 'kiddo@family.com',
     sheetRow: 11,
   },
 
@@ -230,6 +240,7 @@ export const MOCK_ITEMS: ItemWithRow[] = [
     updated_at: daysAgo(2),
     completed_at: '',
     sort_order: 3,
+    created_by: 'mom@family.com',
     sheetRow: 12,
   },
 
@@ -248,6 +259,7 @@ export const MOCK_ITEMS: ItemWithRow[] = [
     updated_at: daysAgo(30),
     completed_at: daysAgo(30),
     sort_order: 2,
+    created_by: 'dad@family.com',
     sheetRow: 13,
   },
 
@@ -266,6 +278,7 @@ export const MOCK_ITEMS: ItemWithRow[] = [
     updated_at: daysAgo(3),
     completed_at: '',
     sort_order: 5,
+    created_by: 'dad@family.com',
     sheetRow: 14,
   },
 
@@ -284,6 +297,7 @@ export const MOCK_ITEMS: ItemWithRow[] = [
     updated_at: daysAgo(1),
     completed_at: '',
     sort_order: 6,
+    created_by: 'kiddo@family.com',
     sheetRow: 15,
   },
 
@@ -302,6 +316,7 @@ export const MOCK_ITEMS: ItemWithRow[] = [
     updated_at: daysAgo(0),
     completed_at: '',
     sort_order: 4,
+    created_by: 'mom@family.com',
     sheetRow: 16,
   },
 ];

--- a/frontend/src/state/actions.ts
+++ b/frontend/src/state/actions.ts
@@ -121,6 +121,7 @@ export async function createItem(
     updated_at: now,
     completed_at: status === 'Done' ? now : '',
     sort_order: maxOrder + 1,
+    created_by: data.created_by || '',
   };
 
   // Optimistic update


### PR DESCRIPTION
## Summary
- Adds a new `CreatedBy` column (column N) to the Items sheet data model
- Frontend captures the authenticated user's email as `created_by` when creating items
- Apps Script stores `created_by` from payload, falls back to `actor` for backward compatibility
- Card detail view displays "Created by: Name" in the metadata section, resolving email to display name via the Owners list
- Items without a creator gracefully show "Unknown"
- Demo mode mock data includes plausible `created_by` values matching owner accounts

## Test plan
- [x] All 204 frontend tests pass (including 3 new tests for created_by display)
- [x] All 12 apps-script tests pass
- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] Production build succeeds (54.75 KB JS, 13.99 KB CSS)
- [ ] Verify in demo mode: card detail shows "Created by: Mom/Dad/Kiddo"
- [ ] Verify in demo mode: creating a new item populates created_by
- [ ] Verify in live mode: new items get creator's email stored in column N

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)