### PR TITLE
Silent re-auth fallback and mid-session token expiry handling

### DIFF
--- a/frontend/src/api/sheets.test.ts
+++ b/frontend/src/api/sheets.test.ts
@@ -1,5 +1,23 @@
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
-import { upsertOwner } from './sheets';
+
+// Mock the reauth module before importing sheets
+vi.mock('../auth/reauth', () => ({
+  attemptReauth: vi.fn(),
+  ReauthFailedError: class ReauthFailedError extends Error {
+    declare cause?: Error;
+    constructor(cause?: Error) {
+      super('Silent re-auth failed');
+      this.name = 'ReauthFailedError';
+      this.cause = cause;
+    }
+  },
+}));
+
+import { upsertOwner, fetchAllItems, fetchOwners, updateItemRow } from './sheets';
+import { attemptReauth } from '../auth/reauth';
+import { ReauthFailedError } from '../auth/reauth';
+
+const mockAttemptReauth = vi.mocked(attemptReauth);
 
 // Mock fetch globally for Sheets API calls
 const mockFetch = vi.fn() as Mock;
@@ -8,6 +26,15 @@ globalThis.fetch = mockFetch;
 // The module reads VITE_SPREADSHEET_ID from import.meta.env.
 // Vitest + Vite makes this available, but we set a fallback via env.
 // Sheets functions build URLs from this, but we mock fetch so the value doesn't matter.
+
+function mock401Response() {
+  return {
+    ok: false,
+    status: 401,
+    json: async () => ({}),
+    text: async () => 'Unauthorized',
+  };
+}
 
 function mockSheetsGetResponse(values: any[][]) {
   return {
@@ -30,6 +57,7 @@ function mockSheetsWriteResponse() {
 describe('upsertOwner', () => {
   beforeEach(() => {
     mockFetch.mockReset();
+    mockAttemptReauth.mockReset();
   });
 
   // Scenario 1: First-time sign-in auto-registers owner
@@ -135,5 +163,143 @@ describe('upsertOwner', () => {
 
     await expect(upsertOwner('Luke', 'luke@example.com', 'test-token'))
       .rejects.toThrow('Sheets API 500');
+  });
+});
+
+// --- AC2: Stale/revoked token on first API call → silent re-auth ---
+describe('withReauth: stale token triggers silent re-auth (AC2)', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockAttemptReauth.mockReset();
+  });
+
+  it('retries fetchAllItems with new token after 401 + successful reauth', async () => {
+    // First call: 401 (stale token)
+    mockFetch.mockResolvedValueOnce(mock401Response());
+    // attemptReauth succeeds with fresh token
+    mockAttemptReauth.mockResolvedValueOnce('fresh-token');
+    // Retry call with fresh token: success
+    mockFetch.mockResolvedValueOnce(
+      mockSheetsGetResponse([
+        ['id-1', 'Task 1', '', 'To Do', '', '', '', '', '', '', '', '', '1', ''],
+      ])
+    );
+
+    const result = await fetchAllItems('stale-token');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe('Task 1');
+    expect(mockAttemptReauth).toHaveBeenCalledTimes(1);
+    // First call used stale token, retry used fresh token
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    const retryHeaders = mockFetch.mock.calls[1][1]?.headers || {};
+    expect(retryHeaders.Authorization || mockFetch.mock.calls[1][0]).toBeDefined();
+  });
+
+  it('retries fetchOwners with new token after 401 + successful reauth', async () => {
+    // First call: 401
+    mockFetch.mockResolvedValueOnce(mock401Response());
+    // Reauth succeeds
+    mockAttemptReauth.mockResolvedValueOnce('fresh-token');
+    // Retry: success
+    mockFetch.mockResolvedValueOnce(
+      mockSheetsGetResponse([['Mom', 'mom@example.com']])
+    );
+
+    const result = await fetchOwners('stale-token');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('Mom');
+    expect(mockAttemptReauth).toHaveBeenCalledTimes(1);
+  });
+});
+
+// --- AC3: Silent re-auth fails after stale token → propagate ReauthFailedError ---
+describe('withReauth: reauth failure propagates (AC3)', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockAttemptReauth.mockReset();
+  });
+
+  it('propagates ReauthFailedError when reauth fails after 401', async () => {
+    // First call: 401
+    mockFetch.mockResolvedValueOnce(mock401Response());
+    // Reauth fails
+    mockAttemptReauth.mockRejectedValueOnce(
+      new ReauthFailedError(new Error('popup blocked'))
+    );
+
+    await expect(fetchAllItems('stale-token')).rejects.toThrow(ReauthFailedError);
+    expect(mockAttemptReauth).toHaveBeenCalledTimes(1);
+    // No retry attempt after reauth failure
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+// --- AC4: Mid-session token expiry → silent re-auth + retry ---
+describe('withReauth: mid-session 401 retries API call (AC4)', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockAttemptReauth.mockReset();
+  });
+
+  it('retries updateItemRow with new token after mid-session 401', async () => {
+    const item = {
+      id: 'id-1', title: 'Test', description: '', status: 'To Do' as const,
+      owner: '', due_date: '', scheduled_date: '', labels: '', parent_id: '',
+      created_at: '', updated_at: '', completed_at: '', sort_order: 1, created_by: '',
+    };
+
+    // First call: 401 (expired token mid-session)
+    mockFetch.mockResolvedValueOnce(mock401Response());
+    // Reauth succeeds
+    mockAttemptReauth.mockResolvedValueOnce('refreshed-token');
+    // Retry: success
+    mockFetch.mockResolvedValueOnce(mockSheetsWriteResponse());
+
+    // Should not throw — retried successfully
+    await updateItemRow(2, item, 'expired-token');
+
+    expect(mockAttemptReauth).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+});
+
+// --- AC5: Mid-session reauth fails → propagate error ---
+describe('withReauth: mid-session reauth failure (AC5)', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockAttemptReauth.mockReset();
+  });
+
+  it('propagates ReauthFailedError when mid-session reauth fails', async () => {
+    const item = {
+      id: 'id-1', title: 'Test', description: '', status: 'To Do' as const,
+      owner: '', due_date: '', scheduled_date: '', labels: '', parent_id: '',
+      created_at: '', updated_at: '', completed_at: '', sort_order: 1, created_by: '',
+    };
+
+    // First call: 401
+    mockFetch.mockResolvedValueOnce(mock401Response());
+    // Reauth fails
+    mockAttemptReauth.mockRejectedValueOnce(
+      new ReauthFailedError(new Error('consent revoked'))
+    );
+
+    await expect(updateItemRow(2, item, 'expired-token'))
+      .rejects.toThrow(ReauthFailedError);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry on non-401 errors', async () => {
+    // 500 error — should not trigger reauth
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      text: async () => 'Server Error',
+    });
+
+    await expect(fetchAllItems('valid-token')).rejects.toThrow('Sheets API 500');
+    expect(mockAttemptReauth).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/api/sheets.ts
+++ b/frontend/src/api/sheets.ts
@@ -2,6 +2,7 @@
 // No gapi.client dependency — smaller, more control.
 
 import type { Item, ItemWithRow, Owner, Label } from './types';
+import { attemptReauth } from '../auth/reauth';
 
 const SPREADSHEET_ID = import.meta.env.VITE_SPREADSHEET_ID;
 const BASE = 'https://sheets.googleapis.com/v4/spreadsheets';
@@ -10,6 +11,24 @@ class SheetsApiError extends Error {
   constructor(public status: number, message: string) {
     super(`Sheets API ${status}: ${message}`);
     this.name = 'SheetsApiError';
+  }
+}
+
+/**
+ * Wrap a Sheets API call with 401 retry logic.
+ * On 401: attempt silent re-auth, then retry once with the new token.
+ * The `callFn` receives a token and performs the actual API call.
+ */
+async function withReauth<T>(token: string, callFn: (t: string) => Promise<T>): Promise<T> {
+  try {
+    return await callFn(token);
+  } catch (err) {
+    if (err instanceof SheetsApiError && err.status === 401) {
+      // Attempt silent re-auth and retry once
+      const newToken = await attemptReauth();
+      return callFn(newToken);
+    }
+    throw err;
   }
 }
 
@@ -110,49 +129,57 @@ function itemToRow(item: Item): any[] {
 // --- Public API ---
 
 export async function fetchAllItems(token: string): Promise<ItemWithRow[]> {
-  const rows = await sheetsGet('Items!A2:N', token);
-  return rows.map((row, i) => ({
-    ...rowToItem(row),
-    sheetRow: i + 2, // 1-based, header is row 1
-  }));
+  return withReauth(token, async (t) => {
+    const rows = await sheetsGet('Items!A2:N', t);
+    return rows.map((row, i) => ({
+      ...rowToItem(row),
+      sheetRow: i + 2, // 1-based, header is row 1
+    }));
+  });
 }
 
 export async function fetchOwners(token: string): Promise<Owner[]> {
-  const rows = await sheetsGet('Owners!A2:B', token);
-  return rows.map(row => ({
-    name: row[0] || '',
-    google_account: row[1] || '',
-  }));
+  return withReauth(token, async (t) => {
+    const rows = await sheetsGet('Owners!A2:B', t);
+    return rows.map(row => ({
+      name: row[0] || '',
+      google_account: row[1] || '',
+    }));
+  });
 }
 
 export async function fetchLabels(token: string): Promise<Label[]> {
-  const rows = await sheetsGet('Labels!A2:B', token);
-  return rows.map(row => ({
-    label: row[0] || '',
-    color: row[1] || '',
-  }));
+  return withReauth(token, async (t) => {
+    const rows = await sheetsGet('Labels!A2:B', t);
+    return rows.map(row => ({
+      label: row[0] || '',
+      color: row[1] || '',
+    }));
+  });
 }
 
 export async function createItemRow(item: Item, token: string): Promise<void> {
-  await sheetsAppend('Items!A:N', [itemToRow(item)], token);
+  return withReauth(token, (t) => sheetsAppend('Items!A:N', [itemToRow(item)], t));
 }
 
 export async function updateItemRow(sheetRow: number, item: Item, token: string): Promise<void> {
-  await sheetsUpdate(`Items!A${sheetRow}:N${sheetRow}`, [itemToRow(item)], token);
+  return withReauth(token, (t) => sheetsUpdate(`Items!A${sheetRow}:N${sheetRow}`, [itemToRow(item)], t));
 }
 
 export async function deleteItemRow(sheetRow: number, token: string): Promise<void> {
-  // Get the Items sheet ID (gid). We need it for batchUpdate.
-  const url = `${BASE}/${SPREADSHEET_ID}?fields=sheets.properties`;
-  const res = await fetch(url, {
-    headers: { Authorization: `Bearer ${token}` },
+  return withReauth(token, async (t) => {
+    // Get the Items sheet ID (gid). We need it for batchUpdate.
+    const url = `${BASE}/${SPREADSHEET_ID}?fields=sheets.properties`;
+    const res = await fetch(url, {
+      headers: { Authorization: `Bearer ${t}` },
+    });
+    const data = await res.json();
+    const itemsSheet = data.sheets?.find(
+      (s: any) => s.properties.title === 'Items'
+    );
+    const sheetId = itemsSheet?.properties?.sheetId ?? 0;
+    await sheetsDeleteRow(sheetId, sheetRow, t);
   });
-  const data = await res.json();
-  const itemsSheet = data.sheets?.find(
-    (s: any) => s.properties.title === 'Items'
-  );
-  const sheetId = itemsSheet?.properties?.sheetId ?? 0;
-  await sheetsDeleteRow(sheetId, sheetRow, token);
 }
 
 /**
@@ -167,28 +194,30 @@ export async function upsertOwner(
   email: string,
   token: string
 ): Promise<boolean> {
-  const rows = await sheetsGet('Owners!A2:B', token);
+  return withReauth(token, async (t) => {
+    const rows = await sheetsGet('Owners!A2:B', t);
 
-  // Find existing row by email (column B)
-  const existingIndex = rows.findIndex(
-    row => (row[1] || '').toLowerCase() === email.toLowerCase()
-  );
+    // Find existing row by email (column B)
+    const existingIndex = rows.findIndex(
+      row => (row[1] || '').toLowerCase() === email.toLowerCase()
+    );
 
-  if (existingIndex >= 0) {
-    // Email already exists — check if name needs updating
-    const existingName = rows[existingIndex][0] || '';
-    if (existingName === name) {
-      return false; // No change needed
+    if (existingIndex >= 0) {
+      // Email already exists — check if name needs updating
+      const existingName = rows[existingIndex][0] || '';
+      if (existingName === name) {
+        return false; // No change needed
+      }
+      // Update the name in the existing row (row index + 2 because header is row 1, data starts at row 2)
+      const sheetRow = existingIndex + 2;
+      await sheetsUpdate(`Owners!A${sheetRow}:B${sheetRow}`, [[name, email]], t);
+      return true;
     }
-    // Update the name in the existing row (row index + 2 because header is row 1, data starts at row 2)
-    const sheetRow = existingIndex + 2;
-    await sheetsUpdate(`Owners!A${sheetRow}:B${sheetRow}`, [[name, email]], token);
-    return true;
-  }
 
-  // Email not found — append new row
-  await sheetsAppend('Owners!A:B', [[name, email]], token);
-  return true;
+    // Email not found — append new row
+    await sheetsAppend('Owners!A:B', [[name, email]], t);
+    return true;
+  });
 }
 
 export async function appendAuditEntry(
@@ -200,9 +229,9 @@ export async function appendAuditEntry(
   actor: string,
   token: string
 ): Promise<void> {
-  await sheetsAppend('Audit Log!A:G', [[
+  return withReauth(token, (t) => sheetsAppend('Audit Log!A:G', [[
     new Date().toISOString(), itemId, action, field, oldValue, newValue, actor,
-  ]], token);
+  ]], t));
 }
 
 export { SheetsApiError };

--- a/frontend/src/auth/auth-provider.tsx
+++ b/frontend/src/auth/auth-provider.tsx
@@ -3,6 +3,8 @@ import type { ComponentChildren } from 'preact';
 import { AuthContext } from './auth-context';
 import type { UserInfo } from '../api/types';
 import { isDemoMode } from '../demo/is-demo-mode';
+import { registerReauthCallback, onReauthFailed } from './reauth';
+import { showToast } from '../state/board-store';
 
 const CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID;
 const SCOPES = 'https://www.googleapis.com/auth/spreadsheets openid email profile';
@@ -11,7 +13,7 @@ const TOKEN_KEY = 'hive_token';
 const USER_KEY = 'hive_user';
 const TOKEN_EXPIRY_KEY = 'hive_token_expiry';
 
-function loadCachedAuth(): { token: string; user: UserInfo; expiry: number } | null {
+export function loadCachedAuth(): { token: string; user: UserInfo; expiry: number } | null {
   try {
     const token = localStorage.getItem(TOKEN_KEY);
     const user = localStorage.getItem(USER_KEY);
@@ -27,7 +29,7 @@ function loadCachedAuth(): { token: string; user: UserInfo; expiry: number } | n
   return null;
 }
 
-function saveCachedAuth(token: string, user: UserInfo, expiresIn: number) {
+export function saveCachedAuth(token: string, user: UserInfo, expiresIn: number) {
   try {
     localStorage.setItem(TOKEN_KEY, token);
     localStorage.setItem(USER_KEY, JSON.stringify(user));
@@ -36,7 +38,7 @@ function saveCachedAuth(token: string, user: UserInfo, expiresIn: number) {
   } catch { /* ignore */ }
 }
 
-function clearCachedAuth() {
+export function clearCachedAuth() {
   try {
     localStorage.removeItem(TOKEN_KEY);
     localStorage.removeItem(USER_KEY);
@@ -64,6 +66,14 @@ export function AuthProvider({ children }: Props) {
   const [user, setUser] = useState<UserInfo | null>(demo ? DEMO_USER : cached?.user ?? null);
   const tokenClientRef = useRef<any>(null);
 
+  /**
+   * Pending reauth resolver. When a silent re-auth is triggered by a 401
+   * in sheets.ts, we store the resolve/reject pair here so the GIS callback
+   * can settle the promise returned to the API layer.
+   */
+  const reauthResolveRef = useRef<((token: string) => void) | null>(null);
+  const reauthRejectRef = useRef<((err: Error) => void) | null>(null);
+
   useEffect(() => {
     // In demo mode, skip GIS initialization entirely.
     if (demo) return;
@@ -82,34 +92,88 @@ export function AuthProvider({ children }: Props) {
         callback: async (response: any) => {
           if (response.error) {
             console.error('OAuth error:', response.error);
+            // If this was a silent reauth attempt, reject the promise
+            if (reauthRejectRef.current) {
+              reauthRejectRef.current(new Error(`OAuth error: ${response.error}`));
+              reauthResolveRef.current = null;
+              reauthRejectRef.current = null;
+            }
             return;
           }
-          setToken(response.access_token);
 
-          // Fetch user info
-          try {
-            const res = await fetch('https://www.googleapis.com/oauth2/v3/userinfo', {
-              headers: { Authorization: `Bearer ${response.access_token}` },
-            });
-            const info = await res.json();
-            const userInfo: UserInfo = {
-              email: info.email,
-              name: info.name,
-              picture: info.picture,
-            };
-            setUser(userInfo);
-            saveCachedAuth(response.access_token, userInfo, response.expires_in || 3600);
-          } catch (err) {
-            console.error('Failed to fetch user info:', err);
+          const newToken = response.access_token;
+          setToken(newToken);
+
+          // Fetch user info (skip if this is a background reauth — use cached user)
+          if (reauthResolveRef.current) {
+            // Silent reauth: resolve the promise with the new token and update cache
+            // Re-use the existing cached user info to avoid an extra network call
+            const cachedUser = loadCachedAuth()?.user;
+            if (cachedUser) {
+              saveCachedAuth(newToken, cachedUser, response.expires_in || 3600);
+            }
+            reauthResolveRef.current(newToken);
+            reauthResolveRef.current = null;
+            reauthRejectRef.current = null;
+          } else {
+            // Normal login: fetch user info
+            try {
+              const res = await fetch('https://www.googleapis.com/oauth2/v3/userinfo', {
+                headers: { Authorization: `Bearer ${newToken}` },
+              });
+              const info = await res.json();
+              const userInfo: UserInfo = {
+                email: info.email,
+                name: info.name,
+                picture: info.picture,
+              };
+              setUser(userInfo);
+              saveCachedAuth(newToken, userInfo, response.expires_in || 3600);
+            } catch (err) {
+              console.error('Failed to fetch user info:', err);
+            }
           }
         },
         error_callback: (error: any) => {
           console.error('Token client error:', error);
+          // If this was a silent reauth attempt, reject the promise
+          if (reauthRejectRef.current) {
+            reauthRejectRef.current(new Error(`Token client error: ${error?.type || error?.message || 'unknown'}`));
+            reauthResolveRef.current = null;
+            reauthRejectRef.current = null;
+          }
         },
       });
     };
 
     init();
+
+    // Register the reauth callback so sheets.ts can trigger silent re-auth on 401
+    const unregisterReauth = registerReauthCallback(() => {
+      return new Promise<string>((resolve, reject) => {
+        if (!tokenClientRef.current) {
+          reject(new Error('GIS token client not initialized'));
+          return;
+        }
+        reauthResolveRef.current = resolve;
+        reauthRejectRef.current = reject;
+        // Request a new token silently (prompt: '' skips consent screen)
+        tokenClientRef.current.requestAccessToken({ prompt: '' });
+      });
+    });
+
+    // Register the reauth-failed callback — clears auth state and shows login
+    const unregisterFailed = onReauthFailed(() => {
+      clearCachedAuth();
+      setToken(null);
+      setUser(null);
+      showToast('Session expired \u2014 please sign in again', 'error');
+    });
+
+    return () => {
+      unregisterReauth();
+      unregisterFailed();
+    };
   }, [demo]);
 
   const login = useCallback(() => {

--- a/frontend/src/auth/reauth.test.ts
+++ b/frontend/src/auth/reauth.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  registerReauthCallback,
+  onReauthFailed,
+  attemptReauth,
+  ReauthFailedError,
+  _resetForTesting,
+} from './reauth';
+
+describe('reauth module', () => {
+  beforeEach(() => {
+    _resetForTesting();
+  });
+
+  it('throws when no callback is registered', async () => {
+    await expect(attemptReauth()).rejects.toThrow('No reauth callback registered');
+  });
+
+  it('calls the registered callback and returns the new token', async () => {
+    const cb = vi.fn().mockResolvedValue('new-token-123');
+    registerReauthCallback(cb);
+
+    const token = await attemptReauth();
+
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(token).toBe('new-token-123');
+  });
+
+  it('calls onReauthFailed callback and throws ReauthFailedError when reauth fails', async () => {
+    const failedCb = vi.fn();
+    const cb = vi.fn().mockRejectedValue(new Error('GIS failed'));
+    registerReauthCallback(cb);
+    onReauthFailed(failedCb);
+
+    await expect(attemptReauth()).rejects.toThrow(ReauthFailedError);
+    expect(failedCb).toHaveBeenCalledTimes(1);
+  });
+
+  it('deduplicates concurrent reauth attempts', async () => {
+    let resolveReauth: (token: string) => void;
+    const cb = vi.fn().mockImplementation(() =>
+      new Promise<string>(resolve => { resolveReauth = resolve; })
+    );
+    registerReauthCallback(cb);
+
+    // Fire two concurrent attempts
+    const p1 = attemptReauth();
+    const p2 = attemptReauth();
+
+    // Only one callback invocation
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    // Resolve the single callback
+    resolveReauth!('deduped-token');
+
+    const [t1, t2] = await Promise.all([p1, p2]);
+    expect(t1).toBe('deduped-token');
+    expect(t2).toBe('deduped-token');
+  });
+
+  it('allows new reauth after previous one completes', async () => {
+    const cb = vi.fn()
+      .mockResolvedValueOnce('token-1')
+      .mockResolvedValueOnce('token-2');
+    registerReauthCallback(cb);
+
+    const t1 = await attemptReauth();
+    const t2 = await attemptReauth();
+
+    expect(t1).toBe('token-1');
+    expect(t2).toBe('token-2');
+    expect(cb).toHaveBeenCalledTimes(2);
+  });
+
+  it('cleanup function unregisters the reauth callback', async () => {
+    const cb = vi.fn().mockResolvedValue('token');
+    const cleanup = registerReauthCallback(cb);
+
+    cleanup();
+
+    await expect(attemptReauth()).rejects.toThrow('No reauth callback registered');
+  });
+
+  it('cleanup function unregisters the onReauthFailed callback', async () => {
+    const failedCb = vi.fn();
+    const cb = vi.fn().mockRejectedValue(new Error('fail'));
+    registerReauthCallback(cb);
+    const cleanup = onReauthFailed(failedCb);
+
+    cleanup();
+
+    // Reauth fails but failedCb should NOT be called
+    await expect(attemptReauth()).rejects.toThrow(ReauthFailedError);
+    expect(failedCb).not.toHaveBeenCalled();
+  });
+
+  it('ReauthFailedError preserves the original cause', async () => {
+    const originalError = new Error('popup blocked');
+    const cb = vi.fn().mockRejectedValue(originalError);
+    registerReauthCallback(cb);
+
+    try {
+      await attemptReauth();
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ReauthFailedError);
+      expect((err as ReauthFailedError).cause).toBe(originalError);
+    }
+  });
+});

--- a/frontend/src/auth/reauth.ts
+++ b/frontend/src/auth/reauth.ts
@@ -1,0 +1,97 @@
+/**
+ * Module-level reauth callback registry.
+ *
+ * sheets.ts is a plain module (not a component) and cannot access Preact context.
+ * auth-provider.tsx registers a reauth callback here at mount time, and sheets.ts
+ * calls it when it encounters a 401 from the Sheets API.
+ *
+ * Flow:
+ *   1. sheets.ts gets a 401 → calls attemptReauth()
+ *   2. attemptReauth() invokes the callback registered by auth-provider
+ *   3. The callback calls GIS requestAccessToken({ prompt: '' }) for silent re-auth
+ *   4. On success → returns the new token; sheets.ts retries the failed call
+ *   5. On failure → throws; sheets.ts propagates the error
+ */
+
+/**
+ * Error thrown when silent re-auth fails. Callers can check for this to
+ * avoid showing duplicate error toasts (the onReauthFailed callback already
+ * shows a toast and forces the user back to the login screen).
+ */
+export class ReauthFailedError extends Error {
+  declare cause?: Error;
+  constructor(cause?: Error) {
+    super('Silent re-auth failed');
+    this.name = 'ReauthFailedError';
+    this.cause = cause;
+  }
+}
+
+type ReauthCallback = () => Promise<string>;
+type ReauthFailedCallback = () => void;
+
+let _reauthCallback: ReauthCallback | null = null;
+let _reauthFailedCallback: ReauthFailedCallback | null = null;
+
+/** Track whether a reauth is already in progress to avoid concurrent attempts. */
+let _reauthInProgress: Promise<string> | null = null;
+
+/**
+ * Register the reauth callback. Called once by auth-provider at mount time.
+ * Returns a cleanup function to unregister.
+ */
+export function registerReauthCallback(cb: ReauthCallback): () => void {
+  _reauthCallback = cb;
+  return () => {
+    _reauthCallback = null;
+  };
+}
+
+/**
+ * Register a callback for when reauth fails (user must re-login).
+ * Called by auth-provider. The callback should clear cached auth and show login.
+ */
+export function onReauthFailed(cb: ReauthFailedCallback): () => void {
+  _reauthFailedCallback = cb;
+  return () => {
+    _reauthFailedCallback = null;
+  };
+}
+
+/**
+ * Attempt silent re-authentication. Called by sheets.ts on 401.
+ * Returns the new access token on success.
+ * Throws on failure (no callback registered, or GIS reauth failed).
+ *
+ * Deduplicates concurrent reauth attempts — if one is already in progress,
+ * subsequent callers wait for the same promise.
+ */
+export async function attemptReauth(): Promise<string> {
+  if (!_reauthCallback) {
+    throw new Error('No reauth callback registered');
+  }
+
+  // Deduplicate: if a reauth is already in flight, piggyback on it
+  if (_reauthInProgress) {
+    return _reauthInProgress;
+  }
+
+  _reauthInProgress = _reauthCallback()
+    .catch((err) => {
+      // Reauth failed — notify auth-provider to clear state and show login
+      _reauthFailedCallback?.();
+      throw new ReauthFailedError(err instanceof Error ? err : undefined);
+    })
+    .finally(() => {
+      _reauthInProgress = null;
+    });
+
+  return _reauthInProgress;
+}
+
+/** Reset all state. Useful for testing. */
+export function _resetForTesting(): void {
+  _reauthCallback = null;
+  _reauthFailedCallback = null;
+  _reauthInProgress = null;
+}

--- a/frontend/src/state/actions.ts
+++ b/frontend/src/state/actions.ts
@@ -19,8 +19,19 @@ import {
   appendAuditEntry as mockAppendAuditEntry,
 } from '../demo/mock-api';
 import { isDemoMode } from '../demo/is-demo-mode';
+import { ReauthFailedError } from '../auth/reauth';
 import { owners, labels, loading } from './board-store';
 import type { Item, ItemStatus, ItemWithRow, UserInfo } from '../api/types';
+
+/**
+ * Check if an error is from a failed silent re-auth attempt.
+ * When reauth fails, the onReauthFailed callback already handles
+ * clearing auth state, showing the login screen, and displaying
+ * a "Session expired" toast — so callers should NOT show an additional toast.
+ */
+function isReauthFailure(err: unknown): boolean {
+  return err instanceof ReauthFailedError;
+}
 
 // Select real or mock API based on demo mode.
 // isDemoMode() is cached after the first call, so this is cheap.
@@ -92,6 +103,7 @@ export async function loadBoard(token: string, user?: UserInfo | null) {
     }
   } catch (err: any) {
     if (err instanceof NotAllowedError) throw err;
+    if (isReauthFailure(err)) return; // Auth layer handles this
     showToast('Failed to load board: ' + err.message, 'error');
   } finally {
     loading.value = false;
@@ -102,6 +114,7 @@ export async function refreshItems(token: string) {
   try {
     items.value = await fetchAllItems(token);
   } catch (err: any) {
+    if (isReauthFailure(err)) return; // Auth layer handles this
     if (err.status === 401) throw err; // Let auth layer handle it
     console.error('Refresh failed:', err);
   }
@@ -158,7 +171,9 @@ export async function createItem(
   } catch (err: any) {
     // Rollback
     items.value = items.value.filter(i => i.id !== item.id);
-    showToast('Failed to create item: ' + err.message, 'error');
+    if (!isReauthFailure(err)) {
+      showToast('Failed to create item: ' + err.message, 'error');
+    }
   }
 }
 
@@ -191,7 +206,9 @@ export async function moveItem(
     return true;
   } catch (err: any) {
     items.value = items.value.map(i => i.id === itemId ? oldItem : i);
-    showToast('Failed to move item: ' + err.message, 'error');
+    if (!isReauthFailure(err)) {
+      showToast('Failed to move item: ' + err.message, 'error');
+    }
     return false;
   }
 }
@@ -234,7 +251,9 @@ export async function updateItem(
     return true;
   } catch (err: any) {
     items.value = items.value.map(i => i.id === itemId ? oldItem : i);
-    showToast('Failed to update item: ' + err.message, 'error');
+    if (!isReauthFailure(err)) {
+      showToast('Failed to update item: ' + err.message, 'error');
+    }
     return false;
   }
 }
@@ -275,6 +294,8 @@ export async function deleteItem(
     showToast('Item deleted');
   } catch (err: any) {
     items.value = oldItems;
-    showToast('Failed to delete item: ' + err.message, 'error');
+    if (!isReauthFailure(err)) {
+      showToast('Failed to delete item: ' + err.message, 'error');
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Add silent re-authentication when a cached OAuth token is stale/revoked (401 on first API call) or expires mid-session (~1 hour GIS token lifetime)
- Intercept 401 responses from the Sheets API, attempt `requestAccessToken({ prompt: '' })` via GIS, and retry the failed call with the new token
- On reauth failure, clear cached auth, show login screen, and display "Session expired" toast

Closes #33

## Changes
- **`frontend/src/auth/reauth.ts`** (new) — Module-level callback registry. `auth-provider` registers a reauth callback at mount time; `sheets.ts` calls `attemptReauth()` on 401. Includes deduplication of concurrent reauth attempts and `ReauthFailedError` for callers to distinguish auth failures from other errors.
- **`frontend/src/api/sheets.ts`** — Added `withReauth()` wrapper that catches `SheetsApiError(401)`, calls `attemptReauth()` for a fresh token, then retries. All public API functions (`fetchAllItems`, `fetchOwners`, `fetchLabels`, `createItemRow`, `updateItemRow`, `deleteItemRow`, `upsertOwner`, `appendAuditEntry`) now use this wrapper.
- **`frontend/src/auth/auth-provider.tsx`** — Registers the GIS reauth callback and reauth-failed handler on mount. On silent reauth: wraps GIS `requestAccessToken` in a Promise, resolves/rejects via refs tied to the GIS callback. On failure: clears localStorage, resets token/user state, shows toast.
- **`frontend/src/state/actions.ts`** — Added `isReauthFailure()` guard to all catch blocks so actions don't show duplicate toasts when the auth layer already handles the "Session expired" flow.

## Testing
- **AC2 (stale token on first call):** `sheets.test.ts` — "retries fetchAllItems/fetchOwners with new token after 401 + successful reauth"
- **AC3 (reauth fails after stale token):** `sheets.test.ts` — "propagates ReauthFailedError when reauth fails after 401"
- **AC4 (mid-session expiry):** `sheets.test.ts` — "retries updateItemRow with new token after mid-session 401"
- **AC5 (mid-session reauth fails):** `sheets.test.ts` — "propagates ReauthFailedError when mid-session reauth fails" + "does not retry on non-401 errors"
- **Reauth module unit tests:** `reauth.test.ts` — 8 tests covering callback registration, cleanup, deduplication, error propagation, and ReauthFailedError cause preservation
- All 239 tests pass, TypeScript compiles cleanly, production build succeeds

## Rules Sync
- [ ] Business rules in `frontend/src/state/rules.ts` updated — N/A (no rule changes)
- [ ] Business rules in `apps-script/src/rules.js` updated — N/A (no rule changes)
- [x] Both files remain in sync