### PR TITLE
feat: custom label creation and management

### DIFF
--- a/frontend/src/api/sheets-labels.test.ts
+++ b/frontend/src/api/sheets-labels.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+
+// Mock the reauth module before importing sheets
+vi.mock('../auth/reauth', () => ({
+  attemptReauth: vi.fn(),
+  ReauthFailedError: class ReauthFailedError extends Error {
+    declare cause?: Error;
+    constructor(cause?: Error) {
+      super('Silent re-auth failed');
+      this.name = 'ReauthFailedError';
+      this.cause = cause;
+    }
+  },
+}));
+
+import {
+  createLabelRow,
+  updateLabelRow,
+  deleteLabelRow,
+  fetchLabelsWithRows,
+  cascadeLabelUpdate,
+} from './sheets';
+
+// Mock fetch globally
+const mockFetch = vi.fn() as Mock;
+globalThis.fetch = mockFetch;
+
+function mockSheetsGetResponse(values: any[][]) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({ values }),
+    text: async () => '',
+  };
+}
+
+function mockSheetsWriteResponse() {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({}),
+    text: async () => '',
+  };
+}
+
+function mockSheetsPropertiesResponse(sheetTitle: string, sheetId: number) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      sheets: [{ properties: { title: sheetTitle, sheetId } }],
+    }),
+    text: async () => '',
+  };
+}
+
+describe('Sheets API label CRUD', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  // Scenario 1: createLabelRow appends to Labels sheet
+  it('createLabelRow appends a new row to Labels sheet', async () => {
+    mockFetch.mockResolvedValueOnce(mockSheetsWriteResponse());
+
+    await createLabelRow('Urgent', '#E74C3C', 'test-token');
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const call = mockFetch.mock.calls[0];
+    const url = call[0] as string;
+    expect(url).toContain('Labels');
+    expect(url).toContain(':append');
+    const body = JSON.parse(call[1].body);
+    expect(body.values).toEqual([['Urgent', '#E74C3C']]);
+  });
+
+  // Scenario 3: updateLabelRow updates a specific row in Labels sheet
+  it('updateLabelRow updates a specific row', async () => {
+    mockFetch.mockResolvedValueOnce(mockSheetsWriteResponse());
+
+    await updateLabelRow(3, 'Renamed', '#00FF00', 'test-token');
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const call = mockFetch.mock.calls[0];
+    const url = call[0] as string;
+    expect(url).toContain('Labels!A3');
+    expect(call[1].method).toBe('PUT');
+    const body = JSON.parse(call[1].body);
+    expect(body.values).toEqual([['Renamed', '#00FF00']]);
+  });
+
+  // Scenario 4: deleteLabelRow finds Labels sheet ID and deletes the row
+  it('deleteLabelRow deletes a row from the Labels sheet', async () => {
+    // First call: get sheet properties
+    mockFetch.mockResolvedValueOnce(mockSheetsPropertiesResponse('Labels', 42));
+    // Second call: batchUpdate to delete row
+    mockFetch.mockResolvedValueOnce(mockSheetsWriteResponse());
+
+    await deleteLabelRow(3, 'test-token');
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    // Verify batchUpdate call
+    const batchCall = mockFetch.mock.calls[1];
+    const batchUrl = batchCall[0] as string;
+    expect(batchUrl).toContain(':batchUpdate');
+    const batchBody = JSON.parse(batchCall[1].body);
+    expect(batchBody.requests[0].deleteDimension.range.sheetId).toBe(42);
+    expect(batchBody.requests[0].deleteDimension.range.startIndex).toBe(2); // 0-based: row 3 - 1
+    expect(batchBody.requests[0].deleteDimension.range.endIndex).toBe(3);
+  });
+
+  // fetchLabelsWithRows returns labels with row numbers
+  it('fetchLabelsWithRows returns labels with sheetRow', async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockSheetsGetResponse([
+        ['Errands', '#42a5f5'],
+        ['Home', '#66bb6a'],
+      ])
+    );
+
+    const result = await fetchLabelsWithRows('test-token');
+
+    expect(result).toEqual([
+      { label: 'Errands', color: '#42a5f5', sheetRow: 2 },
+      { label: 'Home', color: '#66bb6a', sheetRow: 3 },
+    ]);
+  });
+
+  // Scenario 3: cascadeLabelUpdate renames a label in Items
+  it('cascadeLabelUpdate renames a label in items that contain it', async () => {
+    // GET Items!A2:N
+    mockFetch.mockResolvedValueOnce(
+      mockSheetsGetResponse([
+        ['id-1', 'Task 1', '', 'To Do', '', '', '', 'Errands, Home', '', '', '', '', '1', ''],
+        ['id-2', 'Task 2', '', 'To Do', '', '', '', 'Home', '', '', '', '', '2', ''],
+        ['id-3', 'Task 3', '', 'Done', '', '', '', '', '', '', '', '', '3', ''],
+      ])
+    );
+    // PUT for item id-1 (only this item has Errands)
+    mockFetch.mockResolvedValueOnce(mockSheetsWriteResponse());
+
+    await cascadeLabelUpdate('Errands', 'Shopping', 'test-token');
+
+    // Only 2 calls: 1 GET + 1 PUT (only id-1 has Errands)
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    const putCall = mockFetch.mock.calls[1];
+    const putUrl = putCall[0] as string;
+    expect(putUrl).toContain('Items!H2'); // row 2 (index 0 + 2)
+    const putBody = JSON.parse(putCall[1].body);
+    expect(putBody.values).toEqual([['Shopping, Home']]);
+  });
+
+  // Scenario 4: cascadeLabelUpdate removes a label from items when newName is empty
+  it('cascadeLabelUpdate removes a label from items when newName is empty', async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockSheetsGetResponse([
+        ['id-1', 'Task 1', '', 'To Do', '', '', '', 'Errands, Home', '', '', '', '', '1', ''],
+        ['id-2', 'Task 2', '', 'To Do', '', '', '', 'Errands', '', '', '', '', '2', ''],
+      ])
+    );
+    // Two PUT calls (both items have Errands)
+    mockFetch.mockResolvedValueOnce(mockSheetsWriteResponse());
+    mockFetch.mockResolvedValueOnce(mockSheetsWriteResponse());
+
+    await cascadeLabelUpdate('Errands', '', 'test-token');
+
+    expect(mockFetch).toHaveBeenCalledTimes(3); // 1 GET + 2 PUTs
+    // First item: "Home"
+    const put1Body = JSON.parse(mockFetch.mock.calls[1][1].body);
+    expect(put1Body.values).toEqual([['Home']]);
+    // Second item: "" (empty string, Errands was the only label)
+    const put2Body = JSON.parse(mockFetch.mock.calls[2][1].body);
+    expect(put2Body.values).toEqual([['']]);
+  });
+
+  // Edge case: cascadeLabelUpdate with no matching items
+  it('cascadeLabelUpdate does nothing when no items reference the label', async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockSheetsGetResponse([
+        ['id-1', 'Task 1', '', 'To Do', '', '', '', 'Home', '', '', '', '', '1', ''],
+      ])
+    );
+
+    await cascadeLabelUpdate('NonExistent', 'Something', 'test-token');
+
+    // Only the GET call, no PUTs
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/api/sheets.ts
+++ b/frontend/src/api/sheets.ts
@@ -234,4 +234,77 @@ export async function appendAuditEntry(
   ]], t));
 }
 
+// --- Label CRUD ---
+
+export async function createLabelRow(label: string, color: string, token: string): Promise<void> {
+  return withReauth(token, (t) => sheetsAppend('Labels!A:B', [[label, color]], t));
+}
+
+export async function updateLabelRow(sheetRow: number, label: string, color: string, token: string): Promise<void> {
+  return withReauth(token, (t) => sheetsUpdate(`Labels!A${sheetRow}:B${sheetRow}`, [[label, color]], t));
+}
+
+export async function deleteLabelRow(sheetRow: number, token: string): Promise<void> {
+  return withReauth(token, async (t) => {
+    // Get the Labels sheet ID (gid) for batchUpdate row deletion.
+    const url = `${BASE}/${SPREADSHEET_ID}?fields=sheets.properties`;
+    const res = await fetch(url, {
+      headers: { Authorization: `Bearer ${t}` },
+    });
+    const data = await res.json();
+    const labelsSheet = data.sheets?.find(
+      (s: any) => s.properties.title === 'Labels'
+    );
+    const sheetId = labelsSheet?.properties?.sheetId ?? 0;
+    await sheetsDeleteRow(sheetId, sheetRow, t);
+  });
+}
+
+/**
+ * Fetch labels with their sheet row numbers for update/delete operations.
+ */
+export async function fetchLabelsWithRows(token: string): Promise<Array<{ label: string; color: string; sheetRow: number }>> {
+  return withReauth(token, async (t) => {
+    const rows = await sheetsGet('Labels!A2:B', t);
+    return rows.map((row, i) => ({
+      label: row[0] || '',
+      color: row[1] || '',
+      sheetRow: i + 2, // 1-based, header is row 1
+    }));
+  });
+}
+
+/**
+ * Cascade rename or remove a label from all Items that reference it.
+ * Scans the labels column (H) in Items, replacing `oldName` with `newName`
+ * (or removing it entirely if `newName` is empty).
+ */
+export async function cascadeLabelUpdate(
+  oldName: string,
+  newName: string,
+  token: string
+): Promise<void> {
+  return withReauth(token, async (t) => {
+    const rows = await sheetsGet('Items!A2:N', t);
+    for (let i = 0; i < rows.length; i++) {
+      const labelsStr = rows[i][7] || '';
+      const labelsList = labelsStr.split(',').map((l: string) => l.trim()).filter(Boolean);
+      if (!labelsList.includes(oldName)) continue;
+
+      let updated: string[];
+      if (newName) {
+        updated = labelsList.map((l: string) => l === oldName ? newName : l);
+      } else {
+        updated = labelsList.filter((l: string) => l !== oldName);
+      }
+      const newLabelsStr = updated.join(', ');
+      if (newLabelsStr !== labelsStr) {
+        const sheetRow = i + 2;
+        // Update only the labels column (H = column 8)
+        await sheetsUpdate(`Items!H${sheetRow}`, [[newLabelsStr]], t);
+      }
+    }
+  });
+}
+
 export { SheetsApiError };

--- a/frontend/src/components/board/card-detail.tsx
+++ b/frontend/src/components/board/card-detail.tsx
@@ -5,6 +5,7 @@ import { selectedItemId, selectedItem, childrenOfSelected, items, owners, labels
 import { updateItem, deleteItem, createItem, moveItem } from '../../state/actions';
 import { validateOwnerChange } from '../../state/rules';
 import { LabelBadge } from '../shared/label-badge';
+import { LabelPickerManager } from '../labels/label-picker-manager';
 import { useFocusTrap } from '../../hooks/use-focus-trap';
 import { getContrastTextColor } from '../../utils/color';
 import type { ItemStatus } from '../../api/types';
@@ -208,28 +209,19 @@ export function CardDetail() {
 
           <SaveFeedbackField label="Labels">
             {(onFieldSaved) => (
-              <div class="label-picker">
-                {labelsStore.value.map(l => {
+              <LabelPickerManager
+                currentLabels={item.labels}
+                onToggle={async (labelName) => {
                   const currentLabels = item.labels.split(',').map(x => x.trim()).filter(Boolean);
-                  const isActive = currentLabels.includes(l.label);
-                  return (
-                    <button
-                      key={l.label}
-                      class={`label-toggle ${isActive ? 'label-toggle-active' : ''}`}
-                      style={{ '--label-color': l.color, '--label-text-color': getContrastTextColor(l.color) } as any}
-                      onClick={async () => {
-                        const updated = isActive
-                          ? currentLabels.filter(x => x !== l.label)
-                          : [...currentLabels, l.label];
-                        const ok = await save('labels', updated.join(', '));
-                        onFieldSaved(ok);
-                      }}
-                    >
-                      {l.label}
-                    </button>
-                  );
-                })}
-              </div>
+                  const isActive = currentLabels.includes(labelName);
+                  const updated = isActive
+                    ? currentLabels.filter(x => x !== labelName)
+                    : [...currentLabels, labelName];
+                  const ok = await save('labels', updated.join(', '));
+                  onFieldSaved(ok);
+                }}
+                token={token!}
+              />
             )}
           </SaveFeedbackField>
 

--- a/frontend/src/components/forms/create-item-modal.tsx
+++ b/frontend/src/components/forms/create-item-modal.tsx
@@ -2,6 +2,7 @@ import { useState } from 'preact/hooks';
 import { useAuth } from '../../auth/auth-context';
 import { showCreateModal, owners, labels as labelsStore } from '../../state/board-store';
 import { createItem } from '../../state/actions';
+import { LabelPickerManager } from '../labels/label-picker-manager';
 import { getContrastTextColor } from '../../utils/color';
 
 export function CreateItemModal() {
@@ -100,19 +101,11 @@ export function CreateItemModal() {
 
           <div class="form-field">
             <label>Labels</label>
-            <div class="label-picker">
-              {labelsStore.value.map(l => (
-                <button
-                  key={l.label}
-                  type="button"
-                  class={`label-toggle ${selectedLabels.includes(l.label) ? 'label-toggle-active' : ''}`}
-                  style={{ '--label-color': l.color, '--label-text-color': getContrastTextColor(l.color) } as any}
-                  onClick={() => toggleLabel(l.label)}
-                >
-                  {l.label}
-                </button>
-              ))}
-            </div>
+            <LabelPickerManager
+              currentLabels={selectedLabels.join(', ')}
+              onToggle={toggleLabel}
+              token={token!}
+            />
           </div>
 
           <div class="modal-footer">

--- a/frontend/src/components/labels/color-swatch-grid.test.tsx
+++ b/frontend/src/components/labels/color-swatch-grid.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/preact';
+import { ColorSwatchGrid } from './color-swatch-grid';
+import { PRESET_COLORS } from './preset-colors';
+
+// Scenario 6: Color selection via preset swatch grid
+
+describe('ColorSwatchGrid', () => {
+  it('renders 10 color swatches', () => {
+    const { container } = render(
+      <ColorSwatchGrid selectedColor="#E74C3C" onSelect={() => {}} />
+    );
+    const swatches = container.querySelectorAll('[role="radio"]');
+    expect(swatches.length).toBe(PRESET_COLORS.length);
+    expect(swatches.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it('uses role="radiogroup" on the container', () => {
+    const { container } = render(
+      <ColorSwatchGrid selectedColor="#E74C3C" onSelect={() => {}} />
+    );
+    const grid = container.querySelector('[role="radiogroup"]');
+    expect(grid).toBeTruthy();
+    expect(grid!.getAttribute('aria-label')).toBe('Label color');
+  });
+
+  it('marks the selected color with aria-checked="true"', () => {
+    const { container } = render(
+      <ColorSwatchGrid selectedColor="#E74C3C" onSelect={() => {}} />
+    );
+    const swatches = container.querySelectorAll('[role="radio"]');
+    const selected = Array.from(swatches).find(
+      s => s.getAttribute('aria-checked') === 'true'
+    );
+    expect(selected).toBeTruthy();
+    expect(selected!.getAttribute('data-color')).toBe('#E74C3C');
+  });
+
+  it('unselected swatches have aria-checked="false"', () => {
+    const { container } = render(
+      <ColorSwatchGrid selectedColor="#E74C3C" onSelect={() => {}} />
+    );
+    const swatches = container.querySelectorAll('[role="radio"]');
+    const unselected = Array.from(swatches).filter(
+      s => s.getAttribute('aria-checked') === 'false'
+    );
+    expect(unselected.length).toBe(PRESET_COLORS.length - 1);
+  });
+
+  it('each swatch has an aria-label with the color name', () => {
+    const { container } = render(
+      <ColorSwatchGrid selectedColor="" onSelect={() => {}} />
+    );
+    const swatches = container.querySelectorAll('[role="radio"]');
+    swatches.forEach((swatch, i) => {
+      expect(swatch.getAttribute('aria-label')).toBe(PRESET_COLORS[i].name);
+    });
+  });
+
+  it('each swatch has a title tooltip with the color name', () => {
+    const { container } = render(
+      <ColorSwatchGrid selectedColor="" onSelect={() => {}} />
+    );
+    const swatches = container.querySelectorAll('[role="radio"]');
+    swatches.forEach((swatch, i) => {
+      expect(swatch.getAttribute('title')).toBe(PRESET_COLORS[i].name);
+    });
+  });
+
+  it('each swatch is at least 32x32px (has color-swatch class)', () => {
+    const { container } = render(
+      <ColorSwatchGrid selectedColor="" onSelect={() => {}} />
+    );
+    const swatches = container.querySelectorAll('.color-swatch');
+    expect(swatches.length).toBe(PRESET_COLORS.length);
+  });
+
+  it('calls onSelect when a swatch is clicked', () => {
+    const onSelect = vi.fn();
+    const { container } = render(
+      <ColorSwatchGrid selectedColor="" onSelect={onSelect} />
+    );
+    const swatches = container.querySelectorAll('[role="radio"]');
+    (swatches[2] as HTMLElement).click();
+    expect(onSelect).toHaveBeenCalledWith(PRESET_COLORS[2].hex);
+  });
+
+  it('selected swatch has tabindex=0, others have tabindex=-1', () => {
+    const { container } = render(
+      <ColorSwatchGrid selectedColor="#3498DB" onSelect={() => {}} />
+    );
+    const swatches = container.querySelectorAll('[role="radio"]');
+    swatches.forEach(swatch => {
+      if (swatch.getAttribute('data-color') === '#3498DB') {
+        expect(swatch.getAttribute('tabindex')).toBe('0');
+      } else {
+        expect(swatch.getAttribute('tabindex')).toBe('-1');
+      }
+    });
+  });
+
+  it('first swatch gets tabindex=0 when no color is selected', () => {
+    const { container } = render(
+      <ColorSwatchGrid selectedColor="" onSelect={() => {}} />
+    );
+    const swatches = container.querySelectorAll('[role="radio"]');
+    expect(swatches[0].getAttribute('tabindex')).toBe('0');
+    for (let i = 1; i < swatches.length; i++) {
+      expect(swatches[i].getAttribute('tabindex')).toBe('-1');
+    }
+  });
+});

--- a/frontend/src/components/labels/color-swatch-grid.tsx
+++ b/frontend/src/components/labels/color-swatch-grid.tsx
@@ -1,0 +1,83 @@
+import { useRef, useCallback } from 'preact/hooks';
+import { PRESET_COLORS } from './preset-colors';
+
+interface Props {
+  selectedColor: string;
+  onSelect: (hex: string) => void;
+}
+
+const COLUMNS = 5;
+
+/**
+ * Accessible color swatch grid with role="radiogroup" and arrow key navigation.
+ * Each swatch is role="radio" with aria-checked and aria-label.
+ */
+export function ColorSwatchGrid({ selectedColor, onSelect }: Props) {
+  const gridRef = useRef<HTMLDivElement>(null);
+
+  const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    const container = gridRef.current;
+    if (!container) return;
+
+    const swatches = Array.from(container.querySelectorAll<HTMLButtonElement>('[role="radio"]'));
+    const currentIndex = swatches.findIndex(s => s === document.activeElement);
+    if (currentIndex === -1) return;
+
+    let nextIndex = currentIndex;
+    switch (e.key) {
+      case 'ArrowRight':
+        e.preventDefault();
+        nextIndex = (currentIndex + 1) % swatches.length;
+        break;
+      case 'ArrowLeft':
+        e.preventDefault();
+        nextIndex = (currentIndex - 1 + swatches.length) % swatches.length;
+        break;
+      case 'ArrowDown':
+        e.preventDefault();
+        nextIndex = Math.min(currentIndex + COLUMNS, swatches.length - 1);
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        nextIndex = Math.max(currentIndex - COLUMNS, 0);
+        break;
+      case 'Enter':
+      case ' ':
+        e.preventDefault();
+        onSelect(swatches[currentIndex].dataset.color!);
+        return;
+      default:
+        return;
+    }
+    swatches[nextIndex].focus();
+  }, [onSelect]);
+
+  return (
+    <div
+      ref={gridRef}
+      class="color-swatch-grid"
+      role="radiogroup"
+      aria-label="Label color"
+      onKeyDown={handleKeyDown}
+    >
+      {PRESET_COLORS.map((pc, i) => {
+        const isSelected = selectedColor.toUpperCase() === pc.hex.toUpperCase();
+        return (
+          <button
+            key={pc.hex}
+            type="button"
+            role="radio"
+            aria-checked={isSelected}
+            aria-label={pc.name}
+            title={pc.name}
+            class={`color-swatch ${isSelected ? 'color-swatch-selected' : ''}`}
+            style={{ backgroundColor: pc.hex }}
+            data-color={pc.hex}
+            tabIndex={isSelected || (selectedColor === '' && i === 0) ? 0 : -1}
+            onClick={() => onSelect(pc.hex)}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/labels/label-picker-manager.test.tsx
+++ b/frontend/src/components/labels/label-picker-manager.test.tsx
@@ -1,0 +1,365 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, waitFor, cleanup } from '@testing-library/preact';
+import { labels } from '../../state/board-store';
+import { LabelPickerManager } from './label-picker-manager';
+import type { Label } from '../../api/types';
+
+// Mock the actions module
+vi.mock('../../state/actions', () => ({
+  createLabel: vi.fn().mockResolvedValue(undefined),
+  updateLabel: vi.fn().mockResolvedValue(undefined),
+  deleteLabel: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { createLabel, updateLabel, deleteLabel } from '../../state/actions';
+
+const MOCK_LABELS: Label[] = [
+  { label: 'Errands', color: '#42a5f5' },
+  { label: 'Home', color: '#66bb6a' },
+  { label: 'School', color: '#ffa726' },
+];
+
+describe('LabelPickerManager', () => {
+  beforeEach(() => {
+    labels.value = [...MOCK_LABELS];
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // Scenario 8: aria-pressed on label toggles in normal mode
+  it('renders label toggles with aria-pressed in normal mode', () => {
+    const { container } = render(
+      <LabelPickerManager
+        currentLabels="Errands, Home"
+        onToggle={() => {}}
+        token="test-token"
+      />
+    );
+    const toggles = container.querySelectorAll('.label-toggle');
+    expect(toggles.length).toBe(3);
+
+    // Errands is active
+    const errands = Array.from(toggles).find(t => t.textContent === 'Errands')!;
+    expect(errands.getAttribute('aria-pressed')).toBe('true');
+
+    // School is not active
+    const school = Array.from(toggles).find(t => t.textContent === 'School')!;
+    expect(school.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  // Scenario 1: Clicking label toggle in normal mode calls onToggle
+  it('calls onToggle when a label is clicked in normal mode', () => {
+    const onToggle = vi.fn();
+    const { container } = render(
+      <LabelPickerManager
+        currentLabels=""
+        onToggle={onToggle}
+        token="test-token"
+      />
+    );
+    const toggles = container.querySelectorAll('.label-toggle');
+    (toggles[0] as HTMLElement).click();
+    expect(onToggle).toHaveBeenCalledWith('Errands');
+  });
+
+  // Scenario 1: "+ New label" button is visible in normal mode
+  it('shows "+ New label" button in normal mode', () => {
+    const { container } = render(
+      <LabelPickerManager
+        currentLabels=""
+        onToggle={() => {}}
+        token="test-token"
+      />
+    );
+    const btn = container.querySelector('[data-testid="new-label-btn"]');
+    expect(btn).toBeTruthy();
+  });
+
+  // Scenario 1: Clicking "+ New label" shows the inline create form
+  it('shows inline create form when "+ New label" is clicked', async () => {
+    const { container } = render(
+      <LabelPickerManager
+        currentLabels=""
+        onToggle={() => {}}
+        token="test-token"
+      />
+    );
+    expect(container.querySelector('[data-testid="label-form"]')).toBeFalsy();
+    fireEvent.click(container.querySelector('[data-testid="new-label-btn"]')!);
+    expect(container.querySelector('[data-testid="label-form"]')).toBeTruthy();
+    expect(container.querySelector('[data-testid="label-name-input"]')).toBeTruthy();
+  });
+
+  // Scenario 1: Create form has name input, color swatches, Save/Cancel
+  it('create form has name input, color swatch grid, and Save/Cancel buttons', () => {
+    const { container } = render(
+      <LabelPickerManager
+        currentLabels=""
+        onToggle={() => {}}
+        token="test-token"
+      />
+    );
+    fireEvent.click(container.querySelector('[data-testid="new-label-btn"]')!);
+    const form = container.querySelector('[data-testid="label-form"]')!;
+    expect(form.querySelector('.label-form-input')).toBeTruthy();
+    expect(form.querySelector('.color-swatch-grid')).toBeTruthy();
+    expect(container.querySelector('[data-testid="label-save-btn"]')).toBeTruthy();
+    expect(form.querySelector('.btn-ghost')).toBeTruthy(); // Cancel
+  });
+
+  // Scenario 5: Save button disabled when name is empty
+  it('Save button is disabled when name is empty', () => {
+    const { container } = render(
+      <LabelPickerManager
+        currentLabels=""
+        onToggle={() => {}}
+        token="test-token"
+      />
+    );
+    fireEvent.click(container.querySelector('[data-testid="new-label-btn"]')!);
+    const saveBtn = container.querySelector('[data-testid="label-save-btn"]') as HTMLButtonElement;
+    expect(saveBtn.disabled).toBe(true);
+  });
+
+  // Scenario 5: Duplicate label name shows validation error
+  it('shows validation error for duplicate label name', () => {
+    const { container } = render(
+      <LabelPickerManager
+        currentLabels=""
+        onToggle={() => {}}
+        token="test-token"
+      />
+    );
+    fireEvent.click(container.querySelector('[data-testid="new-label-btn"]')!);
+    const input = container.querySelector('[data-testid="label-name-input"]') as HTMLInputElement;
+    fireEvent.input(input, { target: { value: 'errands' } }); // case-insensitive
+    const error = container.querySelector('[data-testid="label-validation-error"]');
+    expect(error).toBeTruthy();
+    expect(error!.textContent).toContain('already exists');
+  });
+
+  // Scenario 5: Name over 30 characters shows validation error
+  it('shows validation error when name exceeds 30 characters', () => {
+    const { container } = render(
+      <LabelPickerManager
+        currentLabels=""
+        onToggle={() => {}}
+        token="test-token"
+      />
+    );
+    fireEvent.click(container.querySelector('[data-testid="new-label-btn"]')!);
+    const input = container.querySelector('[data-testid="label-name-input"]') as HTMLInputElement;
+    fireEvent.input(input, { target: { value: 'A'.repeat(31) } });
+    const error = container.querySelector('[data-testid="label-validation-error"]');
+    expect(error).toBeTruthy();
+    expect(error!.textContent).toContain('30 characters');
+  });
+
+  // Scenario 1: Valid create calls createLabel action
+  it('calls createLabel action with valid name and color', async () => {
+    const { container } = render(
+      <LabelPickerManager
+        currentLabels=""
+        onToggle={() => {}}
+        token="test-token"
+      />
+    );
+    fireEvent.click(container.querySelector('[data-testid="new-label-btn"]')!);
+    const input = container.querySelector('[data-testid="label-name-input"]') as HTMLInputElement;
+    fireEvent.input(input, { target: { value: 'New Label' } });
+    const saveBtn = container.querySelector('[data-testid="label-save-btn"]') as HTMLButtonElement;
+    expect(saveBtn.disabled).toBe(false);
+    fireEvent.click(saveBtn);
+    await waitFor(() => {
+      expect(createLabel).toHaveBeenCalledWith('New Label', expect.any(String), 'test-token');
+    });
+  });
+
+  // Scenario 2: "Manage labels" button toggles edit mode
+  it('shows "Manage labels" button that toggles to "Done"', () => {
+    const { container } = render(
+      <LabelPickerManager
+        currentLabels=""
+        onToggle={() => {}}
+        token="test-token"
+      />
+    );
+    const manageBtn = container.querySelector('[data-testid="manage-labels-btn"]')!;
+    expect(manageBtn.textContent).toBe('Manage labels');
+    fireEvent.click(manageBtn);
+    expect(manageBtn.textContent).toBe('Done');
+    fireEvent.click(manageBtn);
+    expect(manageBtn.textContent).toBe('Manage labels');
+  });
+
+  // Scenario 2: In edit mode, each label has edit and delete icons
+  it('shows edit and delete icons for each label in edit mode', () => {
+    const { container } = render(
+      <LabelPickerManager
+        currentLabels=""
+        onToggle={() => {}}
+        token="test-token"
+      />
+    );
+    fireEvent.click(container.querySelector('[data-testid="manage-labels-btn"]')!);
+    for (const l of MOCK_LABELS) {
+      expect(container.querySelector(`[data-testid="label-edit-${l.label}"]`)).toBeTruthy();
+      expect(container.querySelector(`[data-testid="label-delete-${l.label}"]`)).toBeTruthy();
+    }
+  });
+
+  // Scenario 2: Label toggles are disabled in edit mode
+  it('disables label toggle clicks in edit mode', () => {
+    const onToggle = vi.fn();
+    const { container } = render(
+      <LabelPickerManager
+        currentLabels=""
+        onToggle={onToggle}
+        token="test-token"
+      />
+    );
+    fireEvent.click(container.querySelector('[data-testid="manage-labels-btn"]')!);
+    const toggles = container.querySelectorAll('.label-toggle');
+    (toggles[0] as HTMLElement).click();
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+
+  // Scenario 3: Edit icon opens edit form for a label
+  it('clicking edit icon opens edit form with pre-filled name and color', async () => {
+    const { container } = render(
+      <LabelPickerManager
+        currentLabels=""
+        onToggle={() => {}}
+        token="test-token"
+      />
+    );
+    fireEvent.click(container.querySelector('[data-testid="manage-labels-btn"]')!);
+    fireEvent.click(container.querySelector('[data-testid="label-edit-Errands"]')!);
+    const input = container.querySelector('[data-testid="label-name-input"]') as HTMLInputElement;
+    expect(input).toBeTruthy();
+    expect(input.value).toBe('Errands');
+  });
+
+  // Scenario 3: Saving edit calls updateLabel action
+  it('calls updateLabel when edit form is saved', async () => {
+    const { container } = render(
+      <LabelPickerManager
+        currentLabels=""
+        onToggle={() => {}}
+        token="test-token"
+      />
+    );
+    fireEvent.click(container.querySelector('[data-testid="manage-labels-btn"]')!);
+    fireEvent.click(container.querySelector('[data-testid="label-edit-Errands"]')!);
+    const input = container.querySelector('[data-testid="label-name-input"]') as HTMLInputElement;
+    fireEvent.input(input, { target: { value: 'Shopping' } });
+    fireEvent.click(container.querySelector('[data-testid="label-save-btn"]')!);
+    await waitFor(() => {
+      expect(updateLabel).toHaveBeenCalledWith('Errands', 'Shopping', expect.any(String), 'test-token');
+    });
+  });
+
+  // Scenario 4: Delete icon shows inline confirmation
+  it('clicking delete icon shows inline confirmation', () => {
+    const { container } = render(
+      <LabelPickerManager
+        currentLabels=""
+        onToggle={() => {}}
+        token="test-token"
+      />
+    );
+    fireEvent.click(container.querySelector('[data-testid="manage-labels-btn"]')!);
+    fireEvent.click(container.querySelector('[data-testid="label-delete-Errands"]')!);
+    const confirm = container.querySelector('[data-testid="label-delete-confirm"]');
+    expect(confirm).toBeTruthy();
+    expect(confirm!.textContent).toContain('Remove label from all items?');
+  });
+
+  // Scenario 4: Confirming delete calls deleteLabel action
+  it('calls deleteLabel when delete is confirmed', async () => {
+    const { container } = render(
+      <LabelPickerManager
+        currentLabels=""
+        onToggle={() => {}}
+        token="test-token"
+      />
+    );
+    fireEvent.click(container.querySelector('[data-testid="manage-labels-btn"]')!);
+    fireEvent.click(container.querySelector('[data-testid="label-delete-Errands"]')!);
+    fireEvent.click(container.querySelector('[data-testid="label-delete-confirm-btn"]')!);
+    await waitFor(() => {
+      expect(deleteLabel).toHaveBeenCalledWith('Errands', 'test-token');
+    });
+  });
+
+  // Scenario 4: Cancel delete dismisses confirmation
+  it('cancelling delete dismisses confirmation', () => {
+    const { container } = render(
+      <LabelPickerManager
+        currentLabels=""
+        onToggle={() => {}}
+        token="test-token"
+      />
+    );
+    fireEvent.click(container.querySelector('[data-testid="manage-labels-btn"]')!);
+    fireEvent.click(container.querySelector('[data-testid="label-delete-Errands"]')!);
+    const confirm = container.querySelector('[data-testid="label-delete-confirm"]');
+    expect(confirm).toBeTruthy();
+    // Click cancel
+    const cancelBtn = confirm!.querySelector('.btn-ghost')!;
+    fireEvent.click(cancelBtn);
+    expect(container.querySelector('[data-testid="label-delete-confirm"]')).toBeFalsy();
+  });
+
+  // Scenario 7: Empty state when no labels exist
+  it('shows empty state with create button when no labels exist', () => {
+    labels.value = [];
+    const { container } = render(
+      <LabelPickerManager
+        currentLabels=""
+        onToggle={() => {}}
+        token="test-token"
+      />
+    );
+    expect(container.querySelector('.label-picker-empty')).toBeTruthy();
+    expect(container.textContent).toContain('No labels yet');
+    const createBtn = container.querySelector('.label-picker-empty .btn-primary');
+    expect(createBtn).toBeTruthy();
+    expect(createBtn!.textContent).toContain('Create label');
+  });
+
+  // Scenario 5: Valid name, no duplicate -- Save enabled
+  it('enables Save when name is valid and unique', () => {
+    const { container } = render(
+      <LabelPickerManager
+        currentLabels=""
+        onToggle={() => {}}
+        token="test-token"
+      />
+    );
+    fireEvent.click(container.querySelector('[data-testid="new-label-btn"]')!);
+    const input = container.querySelector('[data-testid="label-name-input"]') as HTMLInputElement;
+    fireEvent.input(input, { target: { value: 'Unique Label' } });
+    const saveBtn = container.querySelector('[data-testid="label-save-btn"]') as HTMLButtonElement;
+    expect(saveBtn.disabled).toBe(false);
+  });
+
+  // Scenario 5: Whitespace-only name keeps Save disabled
+  it('keeps Save disabled for whitespace-only name', () => {
+    const { container } = render(
+      <LabelPickerManager
+        currentLabels=""
+        onToggle={() => {}}
+        token="test-token"
+      />
+    );
+    fireEvent.click(container.querySelector('[data-testid="new-label-btn"]')!);
+    const input = container.querySelector('[data-testid="label-name-input"]') as HTMLInputElement;
+    fireEvent.input(input, { target: { value: '   ' } });
+    const saveBtn = container.querySelector('[data-testid="label-save-btn"]') as HTMLButtonElement;
+    expect(saveBtn.disabled).toBe(true);
+  });
+});

--- a/frontend/src/components/labels/label-picker-manager.tsx
+++ b/frontend/src/components/labels/label-picker-manager.tsx
@@ -1,0 +1,280 @@
+import { useState, useRef } from 'preact/hooks';
+import { labels as labelsStore } from '../../state/board-store';
+import { createLabel, updateLabel, deleteLabel } from '../../state/actions';
+import { getContrastTextColor } from '../../utils/color';
+import { ColorSwatchGrid } from './color-swatch-grid';
+import { PRESET_COLORS } from './preset-colors';
+
+interface Props {
+  /** Currently assigned labels (comma-separated string) */
+  currentLabels: string;
+  /** Called when a label is toggled on/off (only in normal mode) */
+  onToggle: (labelName: string) => void;
+  /** Auth token for API calls */
+  token: string;
+}
+
+type Mode = 'normal' | 'edit';
+type FormMode = 'create' | 'edit-label';
+
+interface FormState {
+  mode: FormMode;
+  name: string;
+  color: string;
+  /** Original label name when editing (for rename tracking) */
+  originalName?: string;
+}
+
+/**
+ * Label picker with inline create, edit, and delete management.
+ * Used by both CardDetail and CreateItemModal.
+ */
+export function LabelPickerManager({ currentLabels, onToggle, token }: Props) {
+  const [mode, setMode] = useState<Mode>('normal');
+  const [form, setForm] = useState<FormState | null>(null);
+  const [confirmingDelete, setConfirmingDelete] = useState<string | null>(null);
+  const nameInputRef = useRef<HTMLInputElement>(null);
+  const newLabelBtnRef = useRef<HTMLButtonElement>(null);
+  const manageBtnRef = useRef<HTMLButtonElement>(null);
+
+  const allLabels = labelsStore.value;
+  const currentLabelsList = currentLabels.split(',').map(x => x.trim()).filter(Boolean);
+
+  // Determine first unused color for new labels
+  const usedColors = new Set(allLabels.map(l => l.color.toUpperCase()));
+  const firstUnusedColor = PRESET_COLORS.find(pc => !usedColors.has(pc.hex.toUpperCase()))?.hex || PRESET_COLORS[0].hex;
+
+  const openCreateForm = () => {
+    setForm({ mode: 'create', name: '', color: firstUnusedColor });
+    setConfirmingDelete(null);
+    requestAnimationFrame(() => nameInputRef.current?.focus());
+  };
+
+  const openEditForm = (labelName: string) => {
+    const label = allLabels.find(l => l.label === labelName);
+    if (!label) return;
+    setForm({ mode: 'edit-label', name: label.label, color: label.color, originalName: label.label });
+    setConfirmingDelete(null);
+    requestAnimationFrame(() => nameInputRef.current?.focus());
+  };
+
+  const closeForm = () => {
+    setForm(null);
+    // Return focus appropriately
+    requestAnimationFrame(() => {
+      if (mode === 'normal') {
+        newLabelBtnRef.current?.focus();
+      } else {
+        manageBtnRef.current?.focus();
+      }
+    });
+  };
+
+  const toggleEditMode = () => {
+    setMode(m => m === 'normal' ? 'edit' : 'normal');
+    setForm(null);
+    setConfirmingDelete(null);
+  };
+
+  // --- Validation ---
+  const validateName = (name: string, originalName?: string): string | null => {
+    const trimmed = name.trim();
+    if (!trimmed) return 'Label name is required';
+    if (trimmed.length > 30) return 'Label name must be 30 characters or fewer';
+    const isDuplicate = allLabels.some(
+      l => l.label.toLowerCase() === trimmed.toLowerCase() &&
+        l.label.toLowerCase() !== (originalName || '').toLowerCase()
+    );
+    if (isDuplicate) return 'A label with this name already exists';
+    return null;
+  };
+
+  const validationError = form ? validateName(form.name, form.originalName) : null;
+  const canSave = form !== null && form.name.trim() !== '' && !validationError && form.color !== '';
+
+  // --- Submit handlers ---
+  const handleSave = async () => {
+    if (!form || !canSave) return;
+    const trimmedName = form.name.trim();
+
+    if (form.mode === 'create') {
+      await createLabel(trimmedName, form.color, token);
+    } else if (form.mode === 'edit-label' && form.originalName) {
+      await updateLabel(form.originalName, trimmedName, form.color, token);
+    }
+    closeForm();
+  };
+
+  const handleDelete = (labelName: string) => {
+    setConfirmingDelete(labelName);
+    setForm(null);
+  };
+
+  const confirmDeleteLabel = async (labelName: string) => {
+    await deleteLabel(labelName, token);
+    setConfirmingDelete(null);
+  };
+
+  const cancelDelete = () => {
+    setConfirmingDelete(null);
+  };
+
+  // --- Empty state ---
+  if (allLabels.length === 0 && !form) {
+    return (
+      <div class="label-picker-empty">
+        <span class="label-picker-empty-text">No labels yet</span>
+        <button
+          type="button"
+          class="btn btn-primary btn-sm"
+          onClick={openCreateForm}
+        >
+          + Create label
+        </button>
+        {form && renderForm()}
+      </div>
+    );
+  }
+
+  function renderForm() {
+    if (!form) return null;
+    return (
+      <div class="label-form" data-testid="label-form">
+        <input
+          ref={nameInputRef}
+          type="text"
+          class="label-form-input"
+          placeholder="Label name..."
+          maxLength={30}
+          value={form.name}
+          onInput={(e) => setForm({ ...form, name: (e.target as HTMLInputElement).value })}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && canSave) { e.preventDefault(); handleSave(); }
+            if (e.key === 'Escape') { e.stopPropagation(); closeForm(); }
+          }}
+          data-testid="label-name-input"
+        />
+        {validationError && form.name.trim() !== '' && (
+          <span class="label-form-error" data-testid="label-validation-error">{validationError}</span>
+        )}
+        <ColorSwatchGrid
+          selectedColor={form.color}
+          onSelect={(hex) => setForm({ ...form, color: hex })}
+        />
+        <div class="label-form-actions">
+          <button type="button" class="btn btn-ghost btn-sm" onClick={closeForm}>Cancel</button>
+          <button
+            type="button"
+            class="btn btn-primary btn-sm"
+            disabled={!canSave}
+            onClick={handleSave}
+            data-testid="label-save-btn"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div class="label-picker-manager">
+      <div class="label-picker">
+        {allLabels.map(l => {
+          const isActive = currentLabelsList.includes(l.label);
+          const isDeleting = confirmingDelete === l.label;
+          const isBeingEdited = form?.mode === 'edit-label' && form.originalName === l.label;
+
+          if (isBeingEdited) {
+            return renderForm();
+          }
+
+          if (isDeleting) {
+            return (
+              <div key={l.label} class="label-delete-confirm" data-testid="label-delete-confirm">
+                <span class="delete-confirm-text">Remove label from all items?</span>
+                <button type="button" class="btn btn-ghost btn-sm" onClick={cancelDelete}>Cancel</button>
+                <button
+                  type="button"
+                  class="btn btn-danger btn-sm"
+                  onClick={() => confirmDeleteLabel(l.label)}
+                  data-testid="label-delete-confirm-btn"
+                >
+                  Remove
+                </button>
+              </div>
+            );
+          }
+
+          return (
+            <div key={l.label} class={`label-toggle-wrapper ${mode === 'edit' ? 'label-toggle-edit-mode' : ''}`}>
+              <button
+                type="button"
+                class={`label-toggle ${isActive ? 'label-toggle-active' : ''}`}
+                style={{ '--label-color': l.color, '--label-text-color': getContrastTextColor(l.color) } as any}
+                aria-pressed={isActive}
+                onClick={() => {
+                  if (mode === 'normal') onToggle(l.label);
+                }}
+                disabled={mode === 'edit'}
+              >
+                {l.label}
+              </button>
+              {mode === 'edit' && (
+                <span class="label-edit-actions">
+                  <button
+                    type="button"
+                    class="btn-icon"
+                    aria-label={`Edit ${l.label}`}
+                    title={`Edit ${l.label}`}
+                    onClick={() => openEditForm(l.label)}
+                    data-testid={`label-edit-${l.label}`}
+                  >
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.85 2.85 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/><path d="m15 5 4 4"/></svg>
+                  </button>
+                  <button
+                    type="button"
+                    class="btn-icon btn-icon-danger"
+                    aria-label={`Delete ${l.label}`}
+                    title={`Delete ${l.label}`}
+                    onClick={() => handleDelete(l.label)}
+                    data-testid={`label-delete-${l.label}`}
+                  >
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/></svg>
+                  </button>
+                </span>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Inline create form (shown below label toggles) */}
+      {form && form.mode === 'create' && renderForm()}
+
+      {/* Action bar: New label + Manage labels */}
+      <div class="label-picker-actions">
+        {mode === 'normal' && !form && (
+          <button
+            ref={newLabelBtnRef}
+            type="button"
+            class="btn btn-ghost btn-sm"
+            onClick={openCreateForm}
+            data-testid="new-label-btn"
+          >
+            + New label
+          </button>
+        )}
+        <button
+          ref={manageBtnRef}
+          type="button"
+          class="btn btn-ghost btn-sm"
+          onClick={toggleEditMode}
+          data-testid="manage-labels-btn"
+        >
+          {mode === 'edit' ? 'Done' : 'Manage labels'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/labels/preset-colors.ts
+++ b/frontend/src/components/labels/preset-colors.ts
@@ -1,0 +1,22 @@
+/**
+ * Curated preset color palette for labels.
+ * Each swatch includes a hex color and a human-readable name for
+ * aria-label and tooltip (colorblind accessibility).
+ */
+export interface PresetColor {
+  hex: string;
+  name: string;
+}
+
+export const PRESET_COLORS: PresetColor[] = [
+  { hex: '#E74C3C', name: 'Tomato Red' },
+  { hex: '#F39C12', name: 'Sunset Orange' },
+  { hex: '#F1C40F', name: 'Sunflower Yellow' },
+  { hex: '#2ECC71', name: 'Emerald Green' },
+  { hex: '#3498DB', name: 'Ocean Blue' },
+  { hex: '#9B59B6', name: 'Royal Purple' },
+  { hex: '#95A5A6', name: 'Slate Gray' },
+  { hex: '#E91E63', name: 'Hot Pink' },
+  { hex: '#00BCD4', name: 'Teal' },
+  { hex: '#795548', name: 'Brown' },
+];

--- a/frontend/src/demo/mock-api-labels.test.ts
+++ b/frontend/src/demo/mock-api-labels.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  fetchLabels,
+  createLabelRow,
+  updateLabelRow,
+  deleteLabelRow,
+  fetchLabelsWithRows,
+  cascadeLabelUpdate,
+  fetchAllItems,
+  resetMockState,
+} from './mock-api';
+import { MOCK_LABELS } from './mock-data';
+
+// Scenario 1: Create a new label (mock API layer)
+// Scenario 3: Edit an existing label (mock API layer)
+// Scenario 4: Delete a label (mock API layer)
+
+describe('Mock API label CRUD', () => {
+  beforeEach(() => {
+    resetMockState();
+  });
+
+  // AC1: createLabelRow appends a label
+  it('createLabelRow adds a label in-memory', async () => {
+    const before = await fetchLabels('demo-token');
+    await createLabelRow('New Label', '#FF0000', 'demo-token');
+    const after = await fetchLabels('demo-token');
+    expect(after.length).toBe(before.length + 1);
+    expect(after.find(l => l.label === 'New Label')).toBeTruthy();
+  });
+
+  // AC3: updateLabelRow modifies an existing label
+  it('updateLabelRow modifies a label in-memory', async () => {
+    const labelsWithRows = await fetchLabelsWithRows('demo-token');
+    const first = labelsWithRows[0];
+    await updateLabelRow(first.sheetRow, 'Renamed', '#00FF00', 'demo-token');
+    const after = await fetchLabels('demo-token');
+    const renamed = after.find(l => l.label === 'Renamed');
+    expect(renamed).toBeTruthy();
+    expect(renamed!.color).toBe('#00FF00');
+    expect(after.find(l => l.label === first.label)).toBeFalsy();
+  });
+
+  // AC4: deleteLabelRow removes a label
+  it('deleteLabelRow removes a label in-memory', async () => {
+    const labelsWithRows = await fetchLabelsWithRows('demo-token');
+    const first = labelsWithRows[0];
+    await deleteLabelRow(first.sheetRow, 'demo-token');
+    const after = await fetchLabels('demo-token');
+    expect(after.find(l => l.label === first.label)).toBeUndefined();
+    expect(after.length).toBe(labelsWithRows.length - 1);
+  });
+
+  // AC3: fetchLabelsWithRows returns row numbers
+  it('fetchLabelsWithRows returns labels with sheetRow numbers', async () => {
+    const labelsWithRows = await fetchLabelsWithRows('demo-token');
+    expect(labelsWithRows.length).toBe(MOCK_LABELS.length);
+    labelsWithRows.forEach(l => {
+      expect(l.sheetRow).toBeGreaterThanOrEqual(2);
+      expect(l.label).toBeTruthy();
+      expect(l.color).toBeTruthy();
+    });
+  });
+
+  // AC3: cascadeLabelUpdate renames a label in items
+  it('cascadeLabelUpdate renames a label in all items that reference it', async () => {
+    // Find an item with labels
+    const items = await fetchAllItems('demo-token');
+    const itemWithLabel = items.find(i => i.labels.includes('Errands'));
+    expect(itemWithLabel).toBeTruthy();
+
+    await cascadeLabelUpdate('Errands', 'Shopping', 'demo-token');
+    const after = await fetchAllItems('demo-token');
+    const updatedItem = after.find(i => i.id === itemWithLabel!.id);
+    expect(updatedItem!.labels).not.toContain('Errands');
+    expect(updatedItem!.labels).toContain('Shopping');
+  });
+
+  // AC4: cascadeLabelUpdate removes a label from items when newName is empty
+  it('cascadeLabelUpdate removes a label from all items when newName is empty', async () => {
+    const items = await fetchAllItems('demo-token');
+    const itemWithLabel = items.find(i => i.labels.includes('Errands'));
+    expect(itemWithLabel).toBeTruthy();
+
+    await cascadeLabelUpdate('Errands', '', 'demo-token');
+    const after = await fetchAllItems('demo-token');
+    const updatedItem = after.find(i => i.id === itemWithLabel!.id);
+    expect(updatedItem!.labels).not.toContain('Errands');
+  });
+
+  // Reset restores labels too
+  it('resetMockState restores labels to original', async () => {
+    await createLabelRow('Temporary', '#000', 'demo-token');
+    const afterCreate = await fetchLabels('demo-token');
+    expect(afterCreate.length).toBe(MOCK_LABELS.length + 1);
+
+    resetMockState();
+    const afterReset = await fetchLabels('demo-token');
+    expect(afterReset.length).toBe(MOCK_LABELS.length);
+  });
+
+  // No HTTP requests made
+  it('no HTTP requests are made for label operations', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    await fetchLabels('demo-token');
+    await createLabelRow('Test', '#FFF', 'demo-token');
+    await fetchLabelsWithRows('demo-token');
+    await updateLabelRow(2, 'Updated', '#000', 'demo-token');
+    await deleteLabelRow(2, 'demo-token');
+    await cascadeLabelUpdate('Test', 'Test2', 'demo-token');
+    expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+});

--- a/frontend/src/demo/mock-api.ts
+++ b/frontend/src/demo/mock-api.ts
@@ -8,10 +8,14 @@ import { MOCK_ITEMS, MOCK_OWNERS, MOCK_LABELS } from './mock-data';
 
 // In-memory state — deep-clone from static data so writes don't mutate the originals.
 const mockItemsState = signal<ItemWithRow[]>(structuredClone(MOCK_ITEMS));
+const mockLabelsState = signal<Array<Label & { sheetRow: number }>>(
+  structuredClone(MOCK_LABELS).map((l, i) => ({ ...l, sheetRow: i + 2 }))
+);
 
 /** Reset in-memory state back to the original mock data (for page refresh behavior). */
 export function resetMockState(): void {
   mockItemsState.value = structuredClone(MOCK_ITEMS);
+  mockLabelsState.value = structuredClone(MOCK_LABELS).map((l, i) => ({ ...l, sheetRow: i + 2 }));
 }
 
 // --- Read operations ---
@@ -25,7 +29,7 @@ export async function fetchOwners(_token: string): Promise<Owner[]> {
 }
 
 export async function fetchLabels(_token: string): Promise<Label[]> {
-  return MOCK_LABELS;
+  return mockLabelsState.value.map(({ label, color }) => ({ label, color }));
 }
 
 // --- Write operations (in-memory only) ---
@@ -65,4 +69,45 @@ export async function upsertOwner(
 ): Promise<boolean> {
   // No-op in demo mode — mock data already has owners.
   return false;
+}
+
+// --- Label CRUD (in-memory) ---
+
+export async function createLabelRow(label: string, color: string, _token: string): Promise<void> {
+  const maxRow = mockLabelsState.value.reduce((max, l) => Math.max(max, l.sheetRow), 1);
+  mockLabelsState.value = [...mockLabelsState.value, { label, color, sheetRow: maxRow + 1 }];
+}
+
+export async function updateLabelRow(sheetRow: number, label: string, color: string, _token: string): Promise<void> {
+  mockLabelsState.value = mockLabelsState.value.map(l =>
+    l.sheetRow === sheetRow ? { label, color, sheetRow } : l
+  );
+}
+
+export async function deleteLabelRow(sheetRow: number, _token: string): Promise<void> {
+  mockLabelsState.value = mockLabelsState.value.filter(l => l.sheetRow !== sheetRow);
+}
+
+export async function fetchLabelsWithRows(_token: string): Promise<Array<{ label: string; color: string; sheetRow: number }>> {
+  return mockLabelsState.value;
+}
+
+export async function cascadeLabelUpdate(
+  oldName: string,
+  newName: string,
+  _token: string
+): Promise<void> {
+  // Update items in-memory: rename or remove the label from all items that reference it.
+  mockItemsState.value = mockItemsState.value.map(item => {
+    const labelsList = item.labels.split(',').map(l => l.trim()).filter(Boolean);
+    if (!labelsList.includes(oldName)) return item;
+
+    let updated: string[];
+    if (newName) {
+      updated = labelsList.map(l => l === oldName ? newName : l);
+    } else {
+      updated = labelsList.filter(l => l !== oldName);
+    }
+    return { ...item, labels: updated.join(', ') };
+  });
 }

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -980,6 +980,156 @@ body {
   line-height: 1.4;
 }
 
+/* === Label Picker Manager === */
+.label-picker-manager {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.label-picker-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.label-picker-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 12px;
+  color: var(--color-text-secondary);
+}
+
+.label-picker-empty-text {
+  font-size: 13px;
+  font-style: italic;
+}
+
+/* Label toggle wrapper for edit mode icons */
+.label-toggle-wrapper {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.label-toggle-edit-mode .label-toggle {
+  cursor: default;
+  opacity: 0.85;
+}
+
+.label-edit-actions {
+  display: inline-flex;
+  gap: 2px;
+}
+
+/* Icon buttons for edit/delete */
+.btn-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  padding: 0;
+  transition: background 0.15s, color 0.15s;
+}
+
+.btn-icon:hover {
+  background: rgba(0, 0, 0, 0.08);
+  color: var(--color-text);
+}
+
+.btn-icon-danger:hover {
+  background: rgba(211, 47, 47, 0.1);
+  color: var(--color-danger);
+}
+
+/* Label form (create/edit) */
+.label-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  background: var(--color-bg);
+}
+
+.label-form-input {
+  padding: 6px 10px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-size: 14px;
+  font-family: inherit;
+  color: var(--color-text);
+}
+
+.label-form-input:focus {
+  border-color: var(--color-primary);
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.label-form-error {
+  font-size: 12px;
+  color: var(--color-danger);
+}
+
+.label-form-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+/* Color swatch grid */
+.color-swatch-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.color-swatch {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 2px solid transparent;
+  cursor: pointer;
+  padding: 0;
+  transition: border-color 0.15s, transform 0.15s;
+}
+
+.color-swatch:hover {
+  transform: scale(1.1);
+}
+
+.color-swatch:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.color-swatch-selected {
+  border-color: var(--color-text);
+  transform: scale(1.1);
+}
+
+/* Label delete confirmation (inline) */
+.label-delete-confirm {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg);
+  flex-wrap: wrap;
+}
+
 /* === Responsive === */
 @media (max-width: 768px) {
   .view-toggle-bar {

--- a/frontend/src/state/actions.test.ts
+++ b/frontend/src/state/actions.test.ts
@@ -10,6 +10,11 @@ vi.mock('../api/sheets', () => ({
   updateItemRow: vi.fn().mockResolvedValue(undefined),
   deleteItemRow: vi.fn().mockResolvedValue(undefined),
   appendAuditEntry: vi.fn().mockResolvedValue(undefined),
+  createLabelRow: vi.fn().mockResolvedValue(undefined),
+  updateLabelRow: vi.fn().mockResolvedValue(undefined),
+  deleteLabelRow: vi.fn().mockResolvedValue(undefined),
+  fetchLabelsWithRows: vi.fn().mockResolvedValue([]),
+  cascadeLabelUpdate: vi.fn().mockResolvedValue(undefined),
   SheetsApiError: class extends Error {
     status: number;
     constructor(status: number, message: string) {
@@ -33,6 +38,11 @@ vi.mock('../demo/mock-api', () => ({
   updateItemRow: vi.fn().mockResolvedValue(undefined),
   deleteItemRow: vi.fn().mockResolvedValue(undefined),
   appendAuditEntry: vi.fn().mockResolvedValue(undefined),
+  createLabelRow: vi.fn().mockResolvedValue(undefined),
+  updateLabelRow: vi.fn().mockResolvedValue(undefined),
+  deleteLabelRow: vi.fn().mockResolvedValue(undefined),
+  fetchLabelsWithRows: vi.fn().mockResolvedValue([]),
+  cascadeLabelUpdate: vi.fn().mockResolvedValue(undefined),
 }));
 
 import { loadBoard, NotAllowedError } from './actions';

--- a/frontend/src/state/actions.ts
+++ b/frontend/src/state/actions.ts
@@ -8,6 +8,11 @@ import {
   updateItemRow as sheetsUpdateItemRow,
   deleteItemRow as sheetsDeleteItemRow,
   appendAuditEntry as sheetsAppendAuditEntry,
+  createLabelRow as sheetsCreateLabelRow,
+  updateLabelRow as sheetsUpdateLabelRow,
+  deleteLabelRow as sheetsDeleteLabelRow,
+  fetchLabelsWithRows as sheetsFetchLabelsWithRows,
+  cascadeLabelUpdate as sheetsCascadeLabelUpdate,
 } from '../api/sheets';
 import {
   fetchAllItems as mockFetchAllItems,
@@ -17,6 +22,11 @@ import {
   updateItemRow as mockUpdateItemRow,
   deleteItemRow as mockDeleteItemRow,
   appendAuditEntry as mockAppendAuditEntry,
+  createLabelRow as mockCreateLabelRow,
+  updateLabelRow as mockUpdateLabelRow,
+  deleteLabelRow as mockDeleteLabelRow,
+  fetchLabelsWithRows as mockFetchLabelsWithRows,
+  cascadeLabelUpdate as mockCascadeLabelUpdate,
 } from '../demo/mock-api';
 import { isDemoMode } from '../demo/is-demo-mode';
 import { ReauthFailedError } from '../auth/reauth';
@@ -45,6 +55,11 @@ function api() {
       updateItemRow: mockUpdateItemRow,
       deleteItemRow: mockDeleteItemRow,
       appendAuditEntry: mockAppendAuditEntry,
+      createLabelRow: mockCreateLabelRow,
+      updateLabelRow: mockUpdateLabelRow,
+      deleteLabelRow: mockDeleteLabelRow,
+      fetchLabelsWithRows: mockFetchLabelsWithRows,
+      cascadeLabelUpdate: mockCascadeLabelUpdate,
     };
   }
   return {
@@ -55,6 +70,11 @@ function api() {
     updateItemRow: sheetsUpdateItemRow,
     deleteItemRow: sheetsDeleteItemRow,
     appendAuditEntry: sheetsAppendAuditEntry,
+    createLabelRow: sheetsCreateLabelRow,
+    updateLabelRow: sheetsUpdateLabelRow,
+    deleteLabelRow: sheetsDeleteLabelRow,
+    fetchLabelsWithRows: sheetsFetchLabelsWithRows,
+    cascadeLabelUpdate: sheetsCascadeLabelUpdate,
   };
 }
 
@@ -65,6 +85,11 @@ const createItemRow = (...args: Parameters<typeof sheetsCreateItemRow>) => api()
 const updateItemRow = (...args: Parameters<typeof sheetsUpdateItemRow>) => api().updateItemRow(...args);
 const deleteItemRow = (...args: Parameters<typeof sheetsDeleteItemRow>) => api().deleteItemRow(...args);
 const appendAuditEntry = (...args: Parameters<typeof sheetsAppendAuditEntry>) => api().appendAuditEntry(...args);
+const createLabelRow = (...args: Parameters<typeof sheetsCreateLabelRow>) => api().createLabelRow(...args);
+const updateLabelRow = (...args: Parameters<typeof sheetsUpdateLabelRow>) => api().updateLabelRow(...args);
+const deleteLabelRow = (...args: Parameters<typeof sheetsDeleteLabelRow>) => api().deleteLabelRow(...args);
+const fetchLabelsWithRows = (...args: Parameters<typeof sheetsFetchLabelsWithRows>) => api().fetchLabelsWithRows(...args);
+const cascadeLabelUpdate = (...args: Parameters<typeof sheetsCascadeLabelUpdate>) => api().cascadeLabelUpdate(...args);
 
 function generateUUID(): string {
   return crypto.randomUUID();
@@ -296,6 +321,123 @@ export async function deleteItem(
     items.value = oldItems;
     if (!isReauthFailure(err)) {
       showToast('Failed to delete item: ' + err.message, 'error');
+    }
+  }
+}
+
+// --- Label CRUD actions ---
+
+export async function refreshLabels(token: string) {
+  try {
+    labels.value = await fetchLabels(token);
+  } catch (err: any) {
+    if (isReauthFailure(err)) return;
+    console.error('Label refresh failed:', err);
+  }
+}
+
+export async function createLabel(
+  name: string,
+  color: string,
+  token: string
+) {
+  // Optimistic update
+  const oldLabels = [...labels.value];
+  labels.value = [...labels.value, { label: name, color }];
+
+  try {
+    await createLabelRow(name, color, token);
+    await refreshLabels(token);
+    showToast('Label created');
+  } catch (err: any) {
+    labels.value = oldLabels;
+    if (!isReauthFailure(err)) {
+      showToast('Failed to create label: ' + err.message, 'error');
+    }
+  }
+}
+
+export async function updateLabel(
+  oldName: string,
+  newName: string,
+  newColor: string,
+  token: string
+) {
+  // Find the label row
+  const labelsWithRows = await fetchLabelsWithRows(token);
+  const labelRow = labelsWithRows.find(l => l.label === oldName);
+  if (!labelRow) {
+    showToast('Label not found', 'error');
+    return;
+  }
+
+  // Optimistic update
+  const oldLabels = [...labels.value];
+  const oldItems = [...items.value];
+  labels.value = labels.value.map(l =>
+    l.label === oldName ? { label: newName, color: newColor } : l
+  );
+  // Also optimistically update items if label was renamed
+  if (oldName !== newName) {
+    items.value = items.value.map(i => {
+      const labelsList = i.labels.split(',').map(x => x.trim()).filter(Boolean);
+      if (!labelsList.includes(oldName)) return i;
+      const updated = labelsList.map(l => l === oldName ? newName : l);
+      return { ...i, labels: updated.join(', ') };
+    });
+  }
+
+  try {
+    await updateLabelRow(labelRow.sheetRow, newName, newColor, token);
+    if (oldName !== newName) {
+      await cascadeLabelUpdate(oldName, newName, token);
+    }
+    await refreshLabels(token);
+    await refreshItems(token);
+    showToast('Label updated');
+  } catch (err: any) {
+    labels.value = oldLabels;
+    items.value = oldItems;
+    if (!isReauthFailure(err)) {
+      showToast('Failed to update label: ' + err.message, 'error');
+    }
+  }
+}
+
+export async function deleteLabel(
+  labelName: string,
+  token: string
+) {
+  // Find the label row
+  const labelsWithRows = await fetchLabelsWithRows(token);
+  const labelRow = labelsWithRows.find(l => l.label === labelName);
+  if (!labelRow) {
+    showToast('Label not found', 'error');
+    return;
+  }
+
+  // Optimistic update
+  const oldLabels = [...labels.value];
+  const oldItems = [...items.value];
+  labels.value = labels.value.filter(l => l.label !== labelName);
+  items.value = items.value.map(i => {
+    const labelsList = i.labels.split(',').map(x => x.trim()).filter(Boolean);
+    if (!labelsList.includes(labelName)) return i;
+    const updated = labelsList.filter(l => l !== labelName);
+    return { ...i, labels: updated.join(', ') };
+  });
+
+  try {
+    await cascadeLabelUpdate(labelName, '', token);
+    await deleteLabelRow(labelRow.sheetRow, token);
+    await refreshLabels(token);
+    await refreshItems(token);
+    showToast('Label deleted');
+  } catch (err: any) {
+    labels.value = oldLabels;
+    items.value = oldItems;
+    if (!isReauthFailure(err)) {
+      showToast('Failed to delete label: ' + err.message, 'error');
     }
   }
 }


### PR DESCRIPTION
## Summary
- Adds inline label CRUD within the existing label picker (Card Detail panel and Create Item modal)
- Users can create new labels with a name and preset color swatch, rename/recolor existing labels, and delete labels with inline confirmation
- Label rename/delete cascades to all Items that reference the affected label
- Includes accessible color swatch grid with `role="radiogroup"`, arrow key navigation, and color name tooltips
- `aria-pressed` on label toggle buttons, empty state when no labels exist, validation (non-empty, unique case-insensitive, max 30 chars)

Closes #26

## Test plan
- [x] 45 new tests added (284 total), all passing
- [x] TypeScript type checking passes (`tsc --noEmit`)
- [x] Production build succeeds (`npm run build`)
- [x] Apps-script tests pass (18/18)
- [ ] Manual test in demo mode: create, rename, recolor, delete labels
- [ ] Manual test: verify cascade rename/delete updates items
- [ ] Manual test: verify empty state when all labels are deleted
- [ ] Manual test: verify accessibility (keyboard navigation, screen reader)

🤖 Generated with [Claude Code](https://claude.com/claude-code)