### PR TITLE
fix: prevent double-submit when adding sub-tasks

### DIFF
--- a/frontend/src/components/board/card-detail.test.tsx
+++ b/frontend/src/components/board/card-detail.test.tsx
@@ -561,6 +561,148 @@ describe('CardDetail inline dialogs (Issue #9)', () => {
   });
 });
 
+describe('CardDetail subtask double-submit fix (Issue #54)', () => {
+  beforeEach(() => {
+    mockSelectedItemId = 'detail-test-1';
+    mockChildren = [];
+    mockItems = [];
+    vi.clearAllMocks();
+  });
+
+  // AC1: Enter creates exactly one sub-task — guard prevents focusout re-trigger.
+  // Note: @testing-library/preact's fireEvent.focusOut does not work with Preact in JSDOM
+  // because 'onfocusout' is not an IDL property of elements in JSDOM 28, causing it to
+  // dispatch an event with type 'FocusOut' (mixed case) which Preact's listener never sees.
+  // We use dispatchEvent(new FocusEvent('focusout', ...)) to dispatch the correct event.
+  it('AC1: pressing Enter creates exactly one sub-task, not two', () => {
+    const { container } = renderCardDetail();
+
+    const addBtn = container.querySelector('.detail-subtasks-header .btn-sm') as HTMLElement;
+    fireEvent.click(addBtn);
+
+    const input = container.querySelector('.subtask-add-input') as HTMLInputElement;
+    const row = container.querySelector('.subtask-add-inline') as HTMLElement;
+
+    fireEvent.input(input, { target: { value: 'Buy milk' } });
+    fireEvent.keyDown(input, { key: 'Enter' }); // submits once, sets guard
+
+    // Simulate focusout on the row — the guard (subtaskSubmittedRef) must prevent a second submit
+    row.dispatchEvent(new FocusEvent('focusout', { bubbles: true, relatedTarget: null }));
+
+    expect(createItem).toHaveBeenCalledTimes(1);
+    expect(createItem).toHaveBeenCalledWith(
+      { title: 'Buy milk', parent_id: 'detail-test-1', owner: 'Luke', created_by: 'luke@example.com' },
+      'Luke',
+      'test-token'
+    );
+  });
+
+  // AC2: Focusout (without Enter) submits exactly once.
+  // Fire on the input so the event bubbles up to the row's onFocusOut handler.
+  // submitSubtask reads subtaskTitleRef (always current) not state (stale closure).
+  it('AC2: focusout submits exactly once when Enter was not pressed', () => {
+    const { container } = renderCardDetail();
+
+    const addBtn = container.querySelector('.detail-subtasks-header .btn-sm') as HTMLElement;
+    fireEvent.click(addBtn);
+
+    const input = container.querySelector('.subtask-add-input') as HTMLInputElement;
+    fireEvent.input(input, { target: { value: 'Walk the dog' } });
+
+    // Dispatch 'focusout' on the input — it bubbles up to the row's Preact handler
+    input.dispatchEvent(new FocusEvent('focusout', { bubbles: true, relatedTarget: null }));
+
+    expect(createItem).toHaveBeenCalledTimes(1);
+    expect(createItem).toHaveBeenCalledWith(
+      { title: 'Walk the dog', parent_id: 'detail-test-1', owner: 'Luke', created_by: 'luke@example.com' },
+      'Luke',
+      'test-token'
+    );
+  });
+
+  // AC3: Escape sets the guard, so focusout afterwards does not create a sub-task
+  it('AC3: Escape cancels and subsequent focusout does not create a sub-task', () => {
+    const { container } = renderCardDetail();
+
+    const addBtn = container.querySelector('.detail-subtasks-header .btn-sm') as HTMLElement;
+    fireEvent.click(addBtn);
+
+    const input = container.querySelector('.subtask-add-input') as HTMLInputElement;
+    const row = container.querySelector('.subtask-add-inline') as HTMLElement;
+
+    fireEvent.input(input, { target: { value: 'Should not save' } });
+    fireEvent.keyDown(input, { key: 'Escape' }); // cancels, sets guard
+
+    // Even if focusout fires, the guard prevents submission
+    row.dispatchEvent(new FocusEvent('focusout', { bubbles: true, relatedTarget: null }));
+
+    expect(createItem).not.toHaveBeenCalled();
+  });
+
+  // AC4: Guard resets between sessions — second sub-task also creates exactly once
+  it('AC4: adding a second sub-task after the first creates exactly one item per session', () => {
+    const { container } = renderCardDetail();
+
+    // First sub-task
+    const addBtn = container.querySelector('.detail-subtasks-header .btn-sm') as HTMLElement;
+    fireEvent.click(addBtn);
+    let input = container.querySelector('.subtask-add-input') as HTMLInputElement;
+    fireEvent.input(input, { target: { value: 'First task' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    // Second sub-task
+    const addBtn2 = container.querySelector('.detail-subtasks-header .btn-sm') as HTMLElement;
+    fireEvent.click(addBtn2);
+    input = container.querySelector('.subtask-add-input') as HTMLInputElement;
+    fireEvent.input(input, { target: { value: 'Second task' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(createItem).toHaveBeenCalledTimes(2);
+    expect((createItem as ReturnType<typeof vi.fn>).mock.calls[0][0].title).toBe('First task');
+    expect((createItem as ReturnType<typeof vi.fn>).mock.calls[1][0].title).toBe('Second task');
+  });
+
+  // AC5: Empty input creates no sub-task on Enter or focusout
+  it('AC5: empty input does not create a sub-task on Enter', () => {
+    const { container } = renderCardDetail();
+
+    const addBtn = container.querySelector('.detail-subtasks-header .btn-sm') as HTMLElement;
+    fireEvent.click(addBtn);
+
+    const input = container.querySelector('.subtask-add-input') as HTMLInputElement;
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(createItem).not.toHaveBeenCalled();
+  });
+
+  it('AC5: whitespace-only input does not create a sub-task on focusout', () => {
+    const { container } = renderCardDetail();
+
+    const addBtn = container.querySelector('.detail-subtasks-header .btn-sm') as HTMLElement;
+    fireEvent.click(addBtn);
+
+    const input = container.querySelector('.subtask-add-input') as HTMLInputElement;
+    fireEvent.input(input, { target: { value: '   ' } });
+
+    const row = container.querySelector('.subtask-add-inline') as HTMLElement;
+    row.dispatchEvent(new FocusEvent('focusout', { bubbles: true, relatedTarget: null }));
+
+    expect(createItem).not.toHaveBeenCalled();
+  });
+
+  // AC6: Sub-task title input has accessible name
+  it('AC6: sub-task title input has aria-label independent of placeholder', () => {
+    const { container } = renderCardDetail();
+
+    const addBtn = container.querySelector('.detail-subtasks-header .btn-sm') as HTMLElement;
+    fireEvent.click(addBtn);
+
+    const input = container.querySelector('.subtask-add-input') as HTMLInputElement;
+    expect(input.getAttribute('aria-label')).toBe('Sub-task title');
+    expect(input.getAttribute('placeholder')).toBe('Sub-task title...');
+  });
+});
+
 describe('CardDetail created_by display (Issue #23)', () => {
   beforeEach(() => {
     mockSelectedItemId = 'detail-test-1';

--- a/frontend/src/components/board/card-detail.tsx
+++ b/frontend/src/components/board/card-detail.tsx
@@ -24,6 +24,11 @@ export function CardDetail() {
   const [subtaskOwner, setSubtaskOwner] = useState(item.owner);
   const subtaskInputRef = useRef<HTMLInputElement>(null);
   const subtaskRowRef = useRef<HTMLDivElement>(null);
+  // Prevents the focusout handler from re-submitting after Enter already triggered submitSubtask
+  const subtaskSubmittedRef = useRef(false);
+  // Mirrors subtaskTitle state so submitSubtask always reads the current value,
+  // avoiding stale-closure problems when focusOut fires before re-render.
+  const subtaskTitleRef = useRef('');
 
   const close = useCallback(() => {
     // Return focus to the triggering card element (AC5)
@@ -68,6 +73,8 @@ export function CardDetail() {
   };
 
   const handleAddSubtask = () => {
+    subtaskSubmittedRef.current = false;
+    subtaskTitleRef.current = '';
     setAddingSubtask(true);
     setSubtaskTitle('');
     setSubtaskOwner(item.owner);
@@ -78,24 +85,32 @@ export function CardDetail() {
   };
 
   const submitSubtask = () => {
-    const trimmed = subtaskTitle.trim();
+    // Guard: Enter keydown unmounts the input row which fires focusout on the container,
+    // which would otherwise call submitSubtask a second time before state has cleared.
+    if (subtaskSubmittedRef.current) return;
+    subtaskSubmittedRef.current = true;
+    // Read from ref to avoid stale closure (focusOut fires before Preact re-renders)
+    const trimmed = subtaskTitleRef.current.trim();
     if (trimmed && token) {
       createItem({ title: trimmed, parent_id: item.id, owner: subtaskOwner, created_by: user?.email || '' }, actor, token);
     }
     setAddingSubtask(false);
     setSubtaskTitle('');
+    subtaskTitleRef.current = '';
   };
 
   const cancelSubtask = () => {
+    subtaskSubmittedRef.current = true; // prevent focusout from submitting on cancel
     setAddingSubtask(false);
     setSubtaskTitle('');
+    subtaskTitleRef.current = '';
   };
 
-  /** Focus-container: only cancel when focus leaves the entire creation row */
+  /** Focus-container: only submit when focus leaves the entire creation row */
   const handleCreationRowFocusOut = (e: FocusEvent) => {
     const container = subtaskRowRef.current;
     const related = e.relatedTarget as Node | null;
-    // If focus moved to another element inside the creation row, don't cancel
+    // If focus moved to another element inside the creation row, don't submit
     if (container && related && container.contains(related)) return;
     submitSubtask();
   };
@@ -324,8 +339,13 @@ export function CardDetail() {
                   type="text"
                   class="subtask-add-input"
                   placeholder="Sub-task title..."
+                  aria-label="Sub-task title"
                   value={subtaskTitle}
-                  onInput={(e) => setSubtaskTitle((e.target as HTMLInputElement).value)}
+                  onInput={(e) => {
+                    const v = (e.target as HTMLInputElement).value;
+                    subtaskTitleRef.current = v;
+                    setSubtaskTitle(v);
+                  }}
                   onKeyDown={(e) => {
                     if (e.key === 'Enter') { e.preventDefault(); submitSubtask(); }
                     if (e.key === 'Escape') { e.stopPropagation(); cancelSubtask(); }

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -1295,6 +1295,11 @@ body {
     min-height: 44px;
   }
 
+  /* Sub-task creation row: 44px min-height for touch targets on mobile */
+  .subtask-add-inline {
+    min-height: 44px;
+  }
+
   /* Touch-friendly action buttons: 44x44px minimum */
   .subtask-action-btn {
     width: 44px;


### PR DESCRIPTION
## Summary

- Adds a `subtaskSubmittedRef` boolean guard to prevent `focusout` from calling `submitSubtask()` a second time after Enter already triggered it
- Adds a `subtaskTitleRef` mirror to eliminate the stale-closure problem (focusout fires before Preact re-renders, so state is stale — ref is always current)
- Adds `aria-label="Sub-task title"` to the creation input (WCAG 2.1 AA)
- Adds `min-height: 44px` to `.subtask-add-inline` in the mobile breakpoint (WCAG 2.1 AA touch target)

Closes #54

## Test plan

- [x] AC1: Enter creates exactly one sub-task (guard blocks focusout re-trigger)
- [x] AC2: Focusout alone submits exactly once (ref prevents stale-closure miss)
- [x] AC3: Escape cancels without creating a sub-task
- [x] AC4: Multiple sub-tasks can be added in sequence (guard resets each session)
- [x] AC5: Empty/whitespace input creates no sub-task
- [x] AC6: Input has `aria-label="Sub-task title"`
- [x] AC7: `.subtask-add-inline` has `min-height: 44px` on mobile (CSS-only, verified in source)
- [x] 333/333 frontend tests pass, 18/18 apps-script tests pass
- [x] `tsc --noEmit` clean, production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)