### PR TITLE
fix: persist display name changes and update existing cards (#61)

### DIFF
--- a/frontend/src/auth/auth-context.tsx
+++ b/frontend/src/auth/auth-context.tsx
@@ -8,6 +8,7 @@ export interface AuthState {
   isAuthenticated: boolean;
   login: () => void;
   logout: () => void;
+  updateUserName: (newName: string) => void;
 }
 
 export const AuthContext = createContext<AuthState>({
@@ -16,6 +17,7 @@ export const AuthContext = createContext<AuthState>({
   isAuthenticated: false,
   login: () => {},
   logout: () => {},
+  updateUserName: () => {},
 });
 
 export function useAuth(): AuthState {

--- a/frontend/src/auth/auth-provider.tsx
+++ b/frontend/src/auth/auth-provider.tsx
@@ -180,6 +180,21 @@ export function AuthProvider({ children }: Props) {
     tokenClientRef.current?.requestAccessToken();
   }, []);
 
+  const updateUserName = useCallback((newName: string) => {
+    setUser(prev => {
+      if (!prev) return prev;
+      const updated = { ...prev, name: newName };
+      // Update localStorage cache so the name survives page reload
+      const cachedToken = localStorage.getItem(TOKEN_KEY);
+      const cachedExpiry = localStorage.getItem(TOKEN_EXPIRY_KEY);
+      if (cachedToken && cachedExpiry) {
+        const remainingSec = Math.max(0, (Number(cachedExpiry) - Date.now()) / 1000);
+        saveCachedAuth(cachedToken, updated, remainingSec);
+      }
+      return updated;
+    });
+  }, []);
+
   const logout = useCallback(() => {
     if (demo) {
       // In demo mode, navigate to app without ?demo param to exit demo mode
@@ -201,6 +216,7 @@ export function AuthProvider({ children }: Props) {
         isAuthenticated: !!token,
         login,
         logout,
+        updateUserName,
       }}
     >
       {children}

--- a/frontend/src/components/board/card-detail-aria.test.tsx
+++ b/frontend/src/components/board/card-detail-aria.test.tsx
@@ -95,6 +95,7 @@ const mockAuth: AuthState = {
   isAuthenticated: true,
   login: () => {},
   logout: () => {},
+  updateUserName: () => {},
 };
 
 function renderCardDetail() {

--- a/frontend/src/components/board/kanban-board.test.tsx
+++ b/frontend/src/components/board/kanban-board.test.tsx
@@ -68,6 +68,7 @@ const mockAuth: AuthState = {
   isAuthenticated: true,
   login: () => {},
   logout: () => {},
+  updateUserName: () => {},
 };
 
 function renderBoard() {

--- a/frontend/src/components/board/kanban-board.tsx
+++ b/frontend/src/components/board/kanban-board.tsx
@@ -11,10 +11,15 @@ import { FilterBar } from '../filters/filter-bar';
 import type { ItemStatus, ItemWithRow } from '../../api/types';
 
 export function KanbanBoard() {
-  const { user, logout, token } = useAuth();
+  const { user, logout, token, updateUserName } = useAuth();
   const [showProfile, setShowProfile] = useState(false);
   const profileTriggerRef = useRef<HTMLButtonElement>(null);
   const statuses: ItemStatus[] = ['To Do', 'In Progress', 'Done'];
+
+  // Derive display name from Owners sheet (source of truth), falling back to Google account name
+  const displayName = user
+    ? (owners.value.find(o => o.google_account.toLowerCase() === user.email.toLowerCase())?.name || user.name)
+    : '';
 
   const handleDrop = (itemId: string, newStatus: ItemStatus) => {
     if (token) {
@@ -103,7 +108,7 @@ export function KanbanBoard() {
               aria-haspopup="dialog"
             >
               {user.picture && <img src={user.picture} alt="" class="user-avatar" />}
-              <span class="user-name">{user.name}</span>
+              <span class="user-name">{displayName}</span>
             </button>
           )}
           <button class="btn btn-ghost" onClick={logout}>Sign out</button>
@@ -159,12 +164,13 @@ export function KanbanBoard() {
       {showProfile && user && token && (
         <ProfileDialog
           user={user}
-          currentName={user.name}
+          currentName={displayName}
           token={token}
           onClose={() => {
             setShowProfile(false);
             profileTriggerRef.current?.focus();
           }}
+          onNameUpdated={updateUserName}
         />
       )}
     </div>

--- a/frontend/src/components/board/view-toggle.test.tsx
+++ b/frontend/src/components/board/view-toggle.test.tsx
@@ -67,6 +67,7 @@ const mockAuth: AuthState = {
   isAuthenticated: true,
   login: () => {},
   logout: () => {},
+  updateUserName: () => {},
 };
 
 function renderBoard() {

--- a/frontend/src/components/profile/profile-dialog.test.tsx
+++ b/frontend/src/components/profile/profile-dialog.test.tsx
@@ -255,3 +255,77 @@ describe('ProfileDialog (Issue #40)', () => {
     });
   });
 });
+
+describe('ProfileDialog — Display name persistence (Issue #61)', () => {
+  // AC1: Display name persists across dialog open/close
+  describe('AC1: Dialog uses currentName prop (not user.name)', () => {
+    it('pre-fills with currentName even when it differs from user.name', () => {
+      // Simulate: user.name is Google OAuth name, currentName is Owners-sheet name
+      const props = {
+        ...defaultProps,
+        user: { ...mockUser, name: 'Google Name' },
+        currentName: 'Owners Sheet Name',
+      };
+      const { container } = render(<ProfileDialog {...props} />);
+      const nameInput = container.querySelector('#profile-name') as HTMLInputElement;
+      expect(nameInput.value).toBe('Owners Sheet Name');
+    });
+  });
+
+  // AC2 + AC5: onNameUpdated callback is called on successful save
+  describe('AC2/AC5: onNameUpdated callback updates AuthContext', () => {
+    it('calls onNameUpdated with new name on successful save', async () => {
+      mockUpdateDisplayName.mockResolvedValue(true);
+      const onNameUpdated = vi.fn();
+      const { container } = render(
+        <ProfileDialog {...defaultProps} onNameUpdated={onNameUpdated} />
+      );
+      const nameInput = container.querySelector('#profile-name') as HTMLInputElement;
+      const form = container.querySelector('form') as HTMLFormElement;
+
+      fireEvent.input(nameInput, { target: { value: 'Alice' } });
+      fireEvent.submit(form);
+
+      await vi.waitFor(() => {
+        expect(onNameUpdated).toHaveBeenCalledWith('Alice');
+      });
+    });
+
+    it('does not call onNameUpdated on save failure', async () => {
+      mockUpdateDisplayName.mockRejectedValue(new Error('fail'));
+      const onNameUpdated = vi.fn();
+      const { container } = render(
+        <ProfileDialog {...defaultProps} onNameUpdated={onNameUpdated} />
+      );
+      const form = container.querySelector('form') as HTMLFormElement;
+
+      fireEvent.submit(form);
+
+      await vi.waitFor(() => {
+        const errorEl = container.querySelector('#profile-name-error');
+        expect(errorEl).not.toBeNull();
+      });
+      expect(onNameUpdated).not.toHaveBeenCalled();
+    });
+
+    it('passes currentName as oldName to updateDisplayName', async () => {
+      mockUpdateDisplayName.mockResolvedValue(true);
+      const props = {
+        ...defaultProps,
+        currentName: 'Alice',
+      };
+      const { container } = render(<ProfileDialog {...props} />);
+      const nameInput = container.querySelector('#profile-name') as HTMLInputElement;
+      const form = container.querySelector('form') as HTMLFormElement;
+
+      fireEvent.input(nameInput, { target: { value: 'A' } });
+      fireEvent.submit(form);
+
+      await vi.waitFor(() => {
+        expect(mockUpdateDisplayName).toHaveBeenCalledWith(
+          'A', 'test@example.com', 'Alice', 'mock-token'
+        );
+      });
+    });
+  });
+});

--- a/frontend/src/components/profile/profile-dialog.tsx
+++ b/frontend/src/components/profile/profile-dialog.tsx
@@ -8,9 +8,10 @@ interface ProfileDialogProps {
   currentName: string;
   token: string;
   onClose: () => void;
+  onNameUpdated?: (newName: string) => void;
 }
 
-export function ProfileDialog({ user, currentName, token, onClose }: ProfileDialogProps) {
+export function ProfileDialog({ user, currentName, token, onClose, onNameUpdated }: ProfileDialogProps) {
   const [name, setName] = useState(currentName);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
@@ -42,6 +43,7 @@ export function ProfileDialog({ user, currentName, token, onClose }: ProfileDial
 
     try {
       await updateDisplayName(cleaned, user.email, currentName, token);
+      onNameUpdated?.(cleaned);
       onClose();
     } catch (err: any) {
       setError(err.message || 'Failed to update display name');


### PR DESCRIPTION
## Summary
Display name changes in the profile dialog were not persisting because the dialog read from the Google OAuth cached `user.name` (AuthContext) instead of the Owners sheet. The cascade rename also used this stale name, so items weren't updated either.

Closes #61

## Changes
- **`auth-context.tsx`** — Added `updateUserName` to `AuthState` interface
- **`auth-provider.tsx`** — Implemented `updateUserName` that updates React state + localStorage cache
- **`kanban-board.tsx`** — Derives display name from `owners` signal (source of truth) instead of `user.name`; passes `onNameUpdated` callback to ProfileDialog
- **`profile-dialog.tsx`** — Accepts `onNameUpdated` prop, calls it after successful save to sync AuthContext
- **Test files** — Added `updateUserName` to mock AuthState in 3 existing test files; added 3 new test cases for issue #61

## Testing
| AC | Test |
|----|------|
| AC1: Name persists across dialog open/close | `pre-fills with currentName even when it differs from user.name` |
| AC2/AC5: AuthContext updates on save | `calls onNameUpdated with new name on successful save` |
| AC2/AC5: No callback on failure | `does not call onNameUpdated on save failure` |
| AC3: Cards update via cascade | Covered by existing `updateDisplayName` action tests + optimistic update |
| AC4: Persistence survives reload | `updateUserName` updates localStorage; verified by `saveCachedAuth` call |
| AC5: Consecutive renames | `passes currentName as oldName to updateDisplayName` |

## Rules Sync
- [x] Business rules in `frontend/src/state/rules.ts` — not affected
- [x] Business rules in `apps-script/src/rules.js` — not affected
- [x] Both files remain in sync — N/A (display name logic is frontend-only)