### PR TITLE
feat: redesign filter UX with chip toggles (#28)

### DIFF
--- a/frontend/src/components/filters/filter-bar.test.tsx
+++ b/frontend/src/components/filters/filter-bar.test.tsx
@@ -1,41 +1,230 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, cleanup } from '@testing-library/preact';
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/preact';
 import { FilterBar } from './filter-bar';
+
+const { mockFilterOwner, mockFilterLabel, mockGroupBy, mockOwners, mockLabels } = vi.hoisted(() => ({
+  mockFilterOwner: { value: null as string | null },
+  mockFilterLabel: { value: null as string | null },
+  mockGroupBy: { value: 'none' },
+  mockOwners: { value: [
+    { name: 'Luke', google_account: 'luke@example.com' },
+    { name: 'Sarah', google_account: 'sarah@example.com' },
+  ]},
+  mockLabels: { value: [
+    { label: 'Urgent', color: '#ff0000' },
+    { label: 'Home', color: '#00cc00' },
+  ]},
+}));
+
+vi.mock('../../state/board-store', () => ({
+  filterOwner: mockFilterOwner,
+  filterLabel: mockFilterLabel,
+  groupBy: mockGroupBy,
+  owners: mockOwners,
+  labels: mockLabels,
+}));
 
 afterEach(() => {
   cleanup();
 });
 
-vi.mock('../../state/board-store', () => ({
-  filterOwner: { value: null },
-  filterLabel: { value: null },
-  groupBy: { value: 'none' },
-  owners: { value: [{ name: 'Luke', google_account: 'luke@example.com' }] },
-  labels: { value: [{ label: 'Urgent', color: '#ff0000' }] },
-}));
+beforeEach(() => {
+  mockFilterOwner.value = null;
+  mockFilterLabel.value = null;
+  mockGroupBy.value = 'none';
+});
 
-describe('FilterBar ARIA labels (Issue #7)', () => {
-  // AC1: Filter bar selects have accessible labels
-  describe('AC1: Filter bar selects have accessible labels', () => {
-    it('owner select has aria-label "Filter by owner"', () => {
+describe('FilterBar chip redesign (Issue #28)', () => {
+  // AC1: Owner filter rendered as chips
+  describe('AC1: Owner filter rendered as chips', () => {
+    it('renders each owner as a button chip (not a select)', () => {
       const { container } = render(<FilterBar />);
-      const selects = container.querySelectorAll('select');
-      const ownerSelect = selects[0] as HTMLSelectElement;
-      expect(ownerSelect.getAttribute('aria-label')).toBe('Filter by owner');
+      const ownerGroup = container.querySelector('[aria-label="Filter by owner"]')!;
+      const chips = ownerGroup.querySelectorAll('button.filter-chip');
+      expect(chips.length).toBe(2);
+      expect(chips[0].textContent).toBe('Luke');
+      expect(chips[1].textContent).toBe('Sarah');
     });
 
-    it('label select has aria-label "Filter by label"', () => {
+    it('tapping an owner chip filters to that owner', () => {
       const { container } = render(<FilterBar />);
-      const selects = container.querySelectorAll('select');
-      const labelSelect = selects[1] as HTMLSelectElement;
-      expect(labelSelect.getAttribute('aria-label')).toBe('Filter by label');
+      const ownerGroup = container.querySelector('[aria-label="Filter by owner"]')!;
+      const lukeChip = ownerGroup.querySelectorAll('button.filter-chip')[0] as HTMLElement;
+      fireEvent.click(lukeChip);
+      expect(mockFilterOwner.value).toBe('Luke');
     });
 
-    it('group-by select has aria-label "Group items by"', () => {
+    it('tapping the active owner chip deselects it', () => {
+      mockFilterOwner.value = 'Luke';
+      const { container } = render(<FilterBar />);
+      const ownerGroup = container.querySelector('[aria-label="Filter by owner"]')!;
+      const lukeChip = ownerGroup.querySelectorAll('button.filter-chip')[0] as HTMLElement;
+      fireEvent.click(lukeChip);
+      expect(mockFilterOwner.value).toBeNull();
+    });
+  });
+
+  // AC2: Label filter rendered as colored chips
+  describe('AC2: Label filter rendered as colored chips', () => {
+    it('renders each label as a button chip', () => {
+      const { container } = render(<FilterBar />);
+      const labelGroup = container.querySelector('[aria-label="Filter by label"]')!;
+      const chips = labelGroup.querySelectorAll('button.filter-chip');
+      expect(chips.length).toBe(2);
+      expect(chips[0].textContent).toBe('Urgent');
+      expect(chips[1].textContent).toBe('Home');
+    });
+
+    it('label chips have the label color as CSS variable', () => {
+      const { container } = render(<FilterBar />);
+      const labelGroup = container.querySelector('[aria-label="Filter by label"]')!;
+      const urgentChip = labelGroup.querySelectorAll('button.filter-chip')[0] as HTMLElement;
+      expect(urgentChip.style.getPropertyValue('--label-color')).toBe('#ff0000');
+    });
+
+    it('tapping a label chip filters to that label', () => {
+      const { container } = render(<FilterBar />);
+      const labelGroup = container.querySelector('[aria-label="Filter by label"]')!;
+      const urgentChip = labelGroup.querySelectorAll('button.filter-chip')[0] as HTMLElement;
+      fireEvent.click(urgentChip);
+      expect(mockFilterLabel.value).toBe('Urgent');
+    });
+
+    it('tapping the active label chip deselects it', () => {
+      mockFilterLabel.value = 'Urgent';
+      const { container } = render(<FilterBar />);
+      const labelGroup = container.querySelector('[aria-label="Filter by label"]')!;
+      const urgentChip = labelGroup.querySelectorAll('button.filter-chip')[0] as HTMLElement;
+      fireEvent.click(urgentChip);
+      expect(mockFilterLabel.value).toBeNull();
+    });
+  });
+
+  // AC3: Combined owner + label filtering
+  describe('AC3: Combined owner + label filtering', () => {
+    it('allows selecting both an owner and a label simultaneously', () => {
+      const { container } = render(<FilterBar />);
+      const ownerGroup = container.querySelector('[aria-label="Filter by owner"]')!;
+      const labelGroup = container.querySelector('[aria-label="Filter by label"]')!;
+
+      fireEvent.click(ownerGroup.querySelectorAll('button.filter-chip')[0] as HTMLElement);
+      fireEvent.click(labelGroup.querySelectorAll('button.filter-chip')[0] as HTMLElement);
+
+      expect(mockFilterOwner.value).toBe('Luke');
+      expect(mockFilterLabel.value).toBe('Urgent');
+    });
+  });
+
+  // AC4: Active chips are visually distinct
+  describe('AC4: Active chips are visually distinct', () => {
+    it('active owner chip has filter-chip-active class', () => {
+      mockFilterOwner.value = 'Luke';
+      const { container } = render(<FilterBar />);
+      const ownerGroup = container.querySelector('[aria-label="Filter by owner"]')!;
+      const lukeChip = ownerGroup.querySelectorAll('button.filter-chip')[0];
+      expect(lukeChip.classList.contains('filter-chip-active')).toBe(true);
+    });
+
+    it('inactive owner chip does not have filter-chip-active class', () => {
+      const { container } = render(<FilterBar />);
+      const ownerGroup = container.querySelector('[aria-label="Filter by owner"]')!;
+      const lukeChip = ownerGroup.querySelectorAll('button.filter-chip')[0];
+      expect(lukeChip.classList.contains('filter-chip-active')).toBe(false);
+    });
+
+    it('shows Clear filters button when a filter is active', () => {
+      mockFilterOwner.value = 'Luke';
+      const { container } = render(<FilterBar />);
+      const clearBtn = container.querySelector('.btn-ghost');
+      expect(clearBtn).not.toBeNull();
+      expect(clearBtn!.textContent).toContain('Clear filters');
+    });
+
+    it('hides Clear filters button when no filters are active', () => {
+      const { container } = render(<FilterBar />);
+      const clearBtn = container.querySelector('.btn-ghost');
+      expect(clearBtn).toBeNull();
+    });
+  });
+
+  // AC5: Clear filters resets all chips
+  describe('AC5: Clear filters resets all chips', () => {
+    it('clicking Clear filters resets owner and label', () => {
+      mockFilterOwner.value = 'Luke';
+      mockFilterLabel.value = 'Urgent';
+      const { container } = render(<FilterBar />);
+      const clearBtn = container.querySelector('.btn-ghost') as HTMLElement;
+      fireEvent.click(clearBtn);
+      expect(mockFilterOwner.value).toBeNull();
+      expect(mockFilterLabel.value).toBeNull();
+    });
+  });
+
+  // AC6: Group-by remains a dropdown
+  describe('AC6: Group-by remains a dropdown', () => {
+    it('renders a single select for group-by', () => {
       const { container } = render(<FilterBar />);
       const selects = container.querySelectorAll('select');
-      const groupBySelect = selects[2] as HTMLSelectElement;
-      expect(groupBySelect.getAttribute('aria-label')).toBe('Group items by');
+      expect(selects.length).toBe(1);
+      expect(selects[0].getAttribute('aria-label')).toBe('Group items by');
+    });
+  });
+
+  // AC8: Keyboard accessible with aria-pressed
+  describe('AC8: Keyboard accessible with aria-pressed', () => {
+    it('inactive chips have aria-pressed="false"', () => {
+      const { container } = render(<FilterBar />);
+      const chips = container.querySelectorAll('button.filter-chip');
+      chips.forEach(chip => {
+        expect(chip.getAttribute('aria-pressed')).toBe('false');
+      });
+    });
+
+    it('active owner chip has aria-pressed="true"', () => {
+      mockFilterOwner.value = 'Luke';
+      const { container } = render(<FilterBar />);
+      const ownerGroup = container.querySelector('[aria-label="Filter by owner"]')!;
+      const lukeChip = ownerGroup.querySelectorAll('button.filter-chip')[0];
+      expect(lukeChip.getAttribute('aria-pressed')).toBe('true');
+    });
+
+    it('active label chip has aria-pressed="true"', () => {
+      mockFilterLabel.value = 'Urgent';
+      const { container } = render(<FilterBar />);
+      const labelGroup = container.querySelector('[aria-label="Filter by label"]')!;
+      const urgentChip = labelGroup.querySelectorAll('button.filter-chip')[0];
+      expect(urgentChip.getAttribute('aria-pressed')).toBe('true');
+    });
+  });
+
+  // AC9: Filter groups are labeled for screen readers
+  describe('AC9: Filter groups are labeled for screen readers', () => {
+    it('owner chips are wrapped in role="group" with aria-label', () => {
+      const { container } = render(<FilterBar />);
+      const ownerGroup = container.querySelector('[role="group"][aria-label="Filter by owner"]');
+      expect(ownerGroup).not.toBeNull();
+    });
+
+    it('label chips are wrapped in role="group" with aria-label', () => {
+      const { container } = render(<FilterBar />);
+      const labelGroup = container.querySelector('[role="group"][aria-label="Filter by label"]');
+      expect(labelGroup).not.toBeNull();
+    });
+
+    it('visible "Owner:" prefix is present', () => {
+      const { container } = render(<FilterBar />);
+      const ownerGroup = container.querySelector('[aria-label="Filter by owner"]')!;
+      const label = ownerGroup.querySelector('.filter-chip-group-label');
+      expect(label).not.toBeNull();
+      expect(label!.textContent).toBe('Owner:');
+    });
+
+    it('visible "Label:" prefix is present', () => {
+      const { container } = render(<FilterBar />);
+      const labelGroup = container.querySelector('[aria-label="Filter by label"]')!;
+      const label = labelGroup.querySelector('.filter-chip-group-label');
+      expect(label).not.toBeNull();
+      expect(label!.textContent).toBe('Label:');
     });
   });
 });

--- a/frontend/src/components/filters/filter-bar.tsx
+++ b/frontend/src/components/filters/filter-bar.tsx
@@ -6,32 +6,48 @@ export function FilterBar() {
   return (
     <div class="filter-bar">
       <div class="filter-group">
-        <select
-          aria-label="Filter by owner"
-          value={filterOwner.value || ''}
-          onChange={(e) => {
-            filterOwner.value = (e.target as HTMLSelectElement).value || null;
-          }}
-        >
-          <option value="">All owners</option>
-          {owners.value.map(o => (
-            <option key={o.name} value={o.name}>{o.name}</option>
-          ))}
-        </select>
+        {/* AC1, AC9: Owner chips in a labeled group */}
+        <div role="group" aria-label="Filter by owner" class="filter-chip-group">
+          <span class="filter-chip-group-label">Owner:</span>
+          {owners.value.map(o => {
+            const active = filterOwner.value === o.name;
+            return (
+              <button
+                key={o.name}
+                class={`filter-chip filter-chip-owner${active ? ' filter-chip-active' : ''}`}
+                aria-pressed={active ? 'true' : 'false'}
+                onClick={() => {
+                  filterOwner.value = active ? null : o.name;
+                }}
+              >
+                {o.name}
+              </button>
+            );
+          })}
+        </div>
 
-        <select
-          aria-label="Filter by label"
-          value={filterLabel.value || ''}
-          onChange={(e) => {
-            filterLabel.value = (e.target as HTMLSelectElement).value || null;
-          }}
-        >
-          <option value="">All labels</option>
-          {labelsStore.value.map(l => (
-            <option key={l.label} value={l.label}>{l.label}</option>
-          ))}
-        </select>
+        {/* AC2, AC9: Label chips in a labeled group */}
+        <div role="group" aria-label="Filter by label" class="filter-chip-group">
+          <span class="filter-chip-group-label">Label:</span>
+          {labelsStore.value.map(l => {
+            const active = filterLabel.value === l.label;
+            return (
+              <button
+                key={l.label}
+                class={`filter-chip filter-chip-label${active ? ' filter-chip-active' : ''}`}
+                aria-pressed={active ? 'true' : 'false'}
+                style={`--label-color: ${l.color}`}
+                onClick={() => {
+                  filterLabel.value = active ? null : l.label;
+                }}
+              >
+                {l.label}
+              </button>
+            );
+          })}
+        </div>
 
+        {/* AC6: Group-by remains a select */}
         <select
           aria-label="Group items by"
           value={groupBy.value}
@@ -44,6 +60,7 @@ export function FilterBar() {
           <option value="label">Group by label</option>
         </select>
 
+        {/* AC4, AC5: Clear filters button */}
         {hasFilters && (
           <button
             class="btn btn-ghost btn-sm"

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -539,6 +539,71 @@ body {
   color: var(--color-text);
 }
 
+/* #28: Filter chip groups */
+.filter-chip-group {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.filter-chip-group-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  white-space: nowrap;
+}
+
+/* #28: Filter chip base */
+.filter-chip {
+  padding: 4px 12px;
+  border: 2px solid var(--color-border);
+  border-radius: 14px;
+  background: transparent;
+  color: var(--color-text);
+  font-size: 13px;
+  cursor: pointer;
+  transition: all 0.15s;
+  white-space: nowrap;
+}
+
+.filter-chip:hover {
+  background: color-mix(in srgb, var(--color-border) 30%, transparent);
+}
+
+/* #28 AC4: Active owner chip — filled primary */
+.filter-chip-owner.filter-chip-active {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: white;
+}
+
+.filter-chip-owner.filter-chip-active:hover {
+  background: var(--color-primary-hover);
+  border-color: var(--color-primary-hover);
+}
+
+/* #28 AC2: Label chips use label color for border */
+.filter-chip-label {
+  border-color: var(--label-color, #999);
+}
+
+.filter-chip-label:hover {
+  background: color-mix(in srgb, var(--label-color, #999) 15%, transparent);
+}
+
+/* #28 AC4: Active label chip — filled with label color */
+.filter-chip-label.filter-chip-active {
+  background: var(--label-color, #999);
+  color: white;
+}
+
+/* #28 AC8: Visible focus indicator for keyboard users */
+.filter-chip:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
 /* === Swimlanes === */
 .board-swimlanes {
   display: flex;
@@ -1441,6 +1506,13 @@ body {
   .filter-bar select {
     min-height: 44px;
     font-size: 16px;
+  }
+
+  /* #28 AC7: Filter chips meet 44px min touch target on mobile */
+  .filter-chip {
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
   }
 
   /* AC5: Mobile card spacing >= 10px gap */


### PR DESCRIPTION
## Summary
Replace native `<select>` dropdowns for owner and label filtering with toggleable chip buttons that show active filters at a glance. Group-by remains a `<select>`.

Closes #28

## Changes
- **filter-bar.tsx**: Replace owner and label `<select>` elements with `<button>` chips in `role="group"` wrappers with `aria-label`. Each chip has `aria-pressed`, toggle-on/off behavior, and visible group labels ("Owner:" / "Label:").
- **global.css**: Add `.filter-chip`, `.filter-chip-group`, active/hover states, label color integration via `--label-color`, `:focus-visible` outline, and 44px mobile touch targets.
- **filter-bar.test.tsx**: Complete rewrite — 21 tests covering all 9 ACs (chip rendering, toggle behavior, deselect, combined filtering, active/inactive styles, clear filters, group-by select, aria-pressed, role="group" wrappers, visible labels).

## Testing
- AC1 (owner chips): 3 tests — renders chips, click filters, click deselects
- AC2 (label chips): 4 tests — renders chips, color variable, click filters, click deselects
- AC3 (combined): 1 test — owner + label simultaneously
- AC4 (visual distinction): 4 tests — active class, inactive class, Clear button shown/hidden
- AC5 (clear filters): 1 test — resets both signals
- AC6 (group-by select): 1 test — single select with aria-label
- AC7 (mobile): CSS-only (44px min-height on chips), verified via build
- AC8 (keyboard): 3 tests — aria-pressed false/true for owner/label
- AC9 (screen readers): 4 tests — role="group", aria-label, visible "Owner:"/"Label:" prefixes

## Rules Sync
- [x] No business rules changed — filtering logic in board-store.ts is unchanged