### PR TITLE
feat: multiple boards with switcher and scoping (#41)

### DIFF
--- a/frontend/src/api/sheets.test.ts
+++ b/frontend/src/api/sheets.test.ts
@@ -248,6 +248,7 @@ describe('withReauth: mid-session 401 retries API call (AC4)', () => {
       id: 'id-1', title: 'Test', description: '', status: 'To Do' as const,
       owner: '', due_date: '', scheduled_date: '', labels: '', parent_id: '',
       created_at: '', updated_at: '', completed_at: '', sort_order: 1, created_by: '',
+      board_id: '',
     };
 
     // First call: 401 (expired token mid-session)
@@ -277,6 +278,7 @@ describe('withReauth: mid-session reauth failure (AC5)', () => {
       id: 'id-1', title: 'Test', description: '', status: 'To Do' as const,
       owner: '', due_date: '', scheduled_date: '', labels: '', parent_id: '',
       created_at: '', updated_at: '', completed_at: '', sort_order: 1, created_by: '',
+      board_id: '',
     };
 
     // First call: 401

--- a/frontend/src/api/sheets.ts
+++ b/frontend/src/api/sheets.ts
@@ -1,7 +1,7 @@
 // Google Sheets REST API wrapper using direct fetch.
 // No gapi.client dependency — smaller, more control.
 
-import type { Item, ItemWithRow, Owner, Label } from './types';
+import type { Item, ItemWithRow, Owner, Label, Board } from './types';
 import { attemptReauth } from '../auth/reauth';
 
 const SPREADSHEET_ID = import.meta.env.VITE_SPREADSHEET_ID;
@@ -114,6 +114,7 @@ function rowToItem(row: any[]): Item {
     completed_at: row[11] || '',
     sort_order: Number(row[12]) || 0,
     created_by: row[13] || '',
+    board_id: row[14] || '',
   };
 }
 
@@ -122,7 +123,7 @@ function itemToRow(item: Item): any[] {
     item.id, item.title, item.description, item.status,
     item.owner, item.due_date, item.scheduled_date, item.labels,
     item.parent_id, item.created_at, item.updated_at, item.completed_at,
-    item.sort_order, item.created_by,
+    item.sort_order, item.created_by, item.board_id,
   ];
 }
 
@@ -130,7 +131,7 @@ function itemToRow(item: Item): any[] {
 
 export async function fetchAllItems(token: string): Promise<ItemWithRow[]> {
   return withReauth(token, async (t) => {
-    const rows = await sheetsGet('Items!A2:N', t);
+    const rows = await sheetsGet('Items!A2:O', t);
     return rows.map((row, i) => ({
       ...rowToItem(row),
       sheetRow: i + 2, // 1-based, header is row 1
@@ -159,11 +160,11 @@ export async function fetchLabels(token: string): Promise<Label[]> {
 }
 
 export async function createItemRow(item: Item, token: string): Promise<void> {
-  return withReauth(token, (t) => sheetsAppend('Items!A:N', [itemToRow(item)], t));
+  return withReauth(token, (t) => sheetsAppend('Items!A:O', [itemToRow(item)], t));
 }
 
 export async function updateItemRow(sheetRow: number, item: Item, token: string): Promise<void> {
-  return withReauth(token, (t) => sheetsUpdate(`Items!A${sheetRow}:N${sheetRow}`, [itemToRow(item)], t));
+  return withReauth(token, (t) => sheetsUpdate(`Items!A${sheetRow}:O${sheetRow}`, [itemToRow(item)], t));
 }
 
 export async function deleteItemRow(sheetRow: number, token: string): Promise<void> {
@@ -285,7 +286,7 @@ export async function cascadeLabelUpdate(
   token: string
 ): Promise<void> {
   return withReauth(token, async (t) => {
-    const rows = await sheetsGet('Items!A2:N', t);
+    const rows = await sheetsGet('Items!A2:O', t);
     for (let i = 0; i < rows.length; i++) {
       const labelsStr = rows[i][7] || '';
       const labelsList = labelsStr.split(',').map((l: string) => l.trim()).filter(Boolean);
@@ -317,7 +318,7 @@ export async function cascadeOwnerUpdate(
   token: string
 ): Promise<void> {
   return withReauth(token, async (t) => {
-    const rows = await sheetsGet('Items!A2:N', t);
+    const rows = await sheetsGet('Items!A2:O', t);
     for (let i = 0; i < rows.length; i++) {
       const owner = rows[i][4] || '';
       if (owner !== oldName) continue;
@@ -326,6 +327,26 @@ export async function cascadeOwnerUpdate(
       await sheetsUpdate(`Items!E${sheetRow}`, [[newName]], t);
     }
   });
+}
+
+// --- Board operations ---
+
+export async function fetchBoards(token: string): Promise<Board[]> {
+  return withReauth(token, async (t) => {
+    const rows = await sheetsGet('Boards!A2:D', t);
+    return rows.map(row => ({
+      id: row[0] || '',
+      name: row[1] || '',
+      created_at: row[2] || '',
+      created_by: row[3] || '',
+    }));
+  });
+}
+
+export async function createBoardRow(board: Board, token: string): Promise<void> {
+  return withReauth(token, (t) => sheetsAppend('Boards!A:D', [[
+    board.id, board.name, board.created_at, board.created_by,
+  ]], t));
 }
 
 export { SheetsApiError };

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -18,6 +18,7 @@ export interface Item {
   completed_at: string;
   sort_order: number;
   created_by: string;
+  board_id: string;
 }
 
 export interface ItemWithRow extends Item {
@@ -33,6 +34,13 @@ export interface Owner {
 export interface Label {
   label: string;
   color: string;
+}
+
+export interface Board {
+  id: string;
+  name: string;
+  created_at: string;
+  created_by: string;
 }
 
 export interface UserInfo {

--- a/frontend/src/components/archive/archive-dialog.test.tsx
+++ b/frontend/src/components/archive/archive-dialog.test.tsx
@@ -44,6 +44,7 @@ function makeItem(overrides: Partial<ItemWithRow>): ItemWithRow {
     completed_at: daysAgoISO(5),
     sort_order: 1,
     created_by: 'test@test.com',
+    board_id: '',
     sheetRow: 2,
     ...overrides,
   };

--- a/frontend/src/components/board/board-switcher.tsx
+++ b/frontend/src/components/board/board-switcher.tsx
@@ -1,0 +1,34 @@
+import { boards, activeBoardId, switchBoard, showCreateBoardModal } from '../../state/board-store';
+
+export function BoardSwitcher() {
+  const currentBoard = boards.value.find(b => b.id === activeBoardId.value);
+
+  const handleChange = (e: Event) => {
+    const value = (e.target as HTMLSelectElement).value;
+    if (value === '__new__') {
+      showCreateBoardModal.value = true;
+      // Reset select to current board so it doesn't show "New Board..."
+      (e.target as HTMLSelectElement).value = activeBoardId.value;
+      return;
+    }
+    switchBoard(value);
+  };
+
+  if (boards.value.length === 0) return null;
+
+  return (
+    <div class="board-switcher" data-testid="board-switcher">
+      <select
+        class="board-switcher-select"
+        value={activeBoardId.value}
+        onChange={handleChange}
+        aria-label="Select board"
+      >
+        {boards.value.map(b => (
+          <option key={b.id} value={b.id}>{b.name}</option>
+        ))}
+        <option value="__new__">+ New Board...</option>
+      </select>
+    </div>
+  );
+}

--- a/frontend/src/components/board/card-detail-aria.test.tsx
+++ b/frontend/src/components/board/card-detail-aria.test.tsx
@@ -33,6 +33,7 @@ vi.mock('../../state/board-store', () => ({
         completed_at: '',
         sort_order: 1,
         created_by: 'luke@example.com',
+        board_id: '',
         sheetRow: 2,
       };
     },
@@ -55,6 +56,7 @@ vi.mock('../../state/board-store', () => ({
           completed_at: '',
           sort_order: 1,
           created_by: 'luke@example.com',
+          board_id: '',
           sheetRow: 3,
         },
         {
@@ -72,6 +74,7 @@ vi.mock('../../state/board-store', () => ({
           completed_at: '2026-01-02T00:00:00Z',
           sort_order: 2,
           created_by: 'luke@example.com',
+          board_id: '',
           sheetRow: 4,
         },
       ];

--- a/frontend/src/components/board/card-detail.test.ts
+++ b/frontend/src/components/board/card-detail.test.ts
@@ -21,6 +21,7 @@ function makeItem(overrides: Partial<ItemWithRow> = {}): ItemWithRow {
     completed_at: '',
     sort_order: 1,
     created_by: 'luke@example.com',
+    board_id: '',
     sheetRow: 2,
     ...overrides,
   };

--- a/frontend/src/components/board/card-mobile.test.tsx
+++ b/frontend/src/components/board/card-mobile.test.tsx
@@ -27,6 +27,7 @@ function makeItem(overrides: Partial<ItemWithRow> = {}): ItemWithRow {
     completed_at: '',
     sort_order: 1,
     created_by: '',
+    board_id: '',
     sheetRow: 2,
     ...overrides,
   };

--- a/frontend/src/components/board/card.test.tsx
+++ b/frontend/src/components/board/card.test.tsx
@@ -27,6 +27,7 @@ function makeItem(overrides: Partial<ItemWithRow> = {}): ItemWithRow {
     completed_at: '',
     sort_order: 1,
     created_by: '',
+    board_id: '',
     sheetRow: 2,
     ...overrides,
   };

--- a/frontend/src/components/board/column.test.tsx
+++ b/frontend/src/components/board/column.test.tsx
@@ -30,6 +30,7 @@ function makeItem(overrides: Partial<ItemWithRow> = {}): ItemWithRow {
     completed_at: '',
     sort_order: 1,
     created_by: '',
+    board_id: '',
     sheetRow: 2,
     ...overrides,
   };

--- a/frontend/src/components/board/create-board-modal.tsx
+++ b/frontend/src/components/board/create-board-modal.tsx
@@ -1,0 +1,124 @@
+import { useState, useEffect, useRef } from 'preact/hooks';
+import { useAuth } from '../../auth/auth-context';
+import { showCreateBoardModal, boards } from '../../state/board-store';
+import { createBoard } from '../../state/actions';
+
+const MAX_NAME_LENGTH = 30;
+
+export function CreateBoardModal() {
+  const { token, user } = useAuth();
+  const [name, setName] = useState('');
+  const [error, setError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const triggerRef = useRef<Element | null>(null);
+
+  useEffect(() => {
+    // Store the element that had focus when modal opened
+    triggerRef.current = document.activeElement;
+    // Focus input on mount
+    inputRef.current?.focus();
+  }, []);
+
+  const close = () => {
+    showCreateBoardModal.value = false;
+    // Return focus to trigger element
+    if (triggerRef.current instanceof HTMLElement) {
+      triggerRef.current.focus();
+    }
+  };
+
+  const validate = (value: string): string => {
+    const trimmed = value.trim();
+    if (!trimmed) return 'Board name is required';
+    if (trimmed.length > MAX_NAME_LENGTH) return `Name must be ${MAX_NAME_LENGTH} characters or fewer`;
+    if (boards.value.some(b => b.name.toLowerCase() === trimmed.toLowerCase())) {
+      return 'A board with this name already exists';
+    }
+    return '';
+  };
+
+  const handleSubmit = async (e: Event) => {
+    e.preventDefault();
+    const validationError = validate(name);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    if (!token) return;
+
+    setSubmitting(true);
+    const success = await createBoard(name, user?.email || '', token);
+    setSubmitting(false);
+
+    if (success) {
+      close();
+    }
+  };
+
+  const handleInput = (e: Event) => {
+    const value = (e.target as HTMLInputElement).value;
+    setName(value);
+    if (error) setError(validate(value));
+  };
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.stopPropagation();
+      close();
+    }
+  };
+
+  return (
+    <div
+      class="modal-overlay"
+      onClick={(e) => {
+        if ((e.target as HTMLElement).classList.contains('modal-overlay')) close();
+      }}
+      onKeyDown={handleKeyDown}
+    >
+      <div class="modal create-board-modal" role="dialog" aria-label="Create new board" aria-modal="true">
+        <div class="modal-header">
+          <h2>New Board</h2>
+          <button class="btn btn-ghost" onClick={close} aria-label="Close">✕</button>
+        </div>
+
+        <form onSubmit={handleSubmit}>
+          <div class="form-field">
+            <label for="board-name">Board Name</label>
+            <input
+              id="board-name"
+              ref={inputRef}
+              type="text"
+              value={name}
+              onInput={handleInput}
+              placeholder="e.g., Home Tasks"
+              maxLength={MAX_NAME_LENGTH}
+              aria-invalid={error ? 'true' : undefined}
+              aria-describedby={error ? 'board-name-error' : undefined}
+            />
+            <div class="board-name-meta">
+              {error && (
+                <span id="board-name-error" class="form-error" role="alert">{error}</span>
+              )}
+              <span class={`char-counter ${name.length > MAX_NAME_LENGTH ? 'char-counter-danger' : name.length > MAX_NAME_LENGTH - 5 ? 'char-counter-warning' : ''}`}>
+                {name.length}/{MAX_NAME_LENGTH}
+              </span>
+            </div>
+          </div>
+
+          <div class="modal-footer">
+            <button type="button" class="btn btn-ghost" onClick={close}>Cancel</button>
+            <button
+              type="submit"
+              class="btn btn-primary"
+              disabled={!name.trim() || submitting}
+            >
+              {submitting ? 'Creating...' : 'Create'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/board/kanban-board.test.tsx
+++ b/frontend/src/components/board/kanban-board.test.tsx
@@ -40,6 +40,9 @@ vi.mock('../../state/board-store', () => ({
   allDoneItems: { value: [] },
   hasArchivedItems: { value: false },
   showArchiveDialog: { value: false },
+  boards: { value: [] },
+  boardItems: { get value() { return mockItems; } },
+  showCreateBoardModal: { value: false },
 }));
 
 vi.mock('../../state/actions', () => ({
@@ -60,6 +63,12 @@ vi.mock('./card-detail', () => ({
 }));
 vi.mock('../forms/create-item-modal', () => ({
   CreateItemModal: () => <div data-testid="create-modal" />,
+}));
+vi.mock('./board-switcher', () => ({
+  BoardSwitcher: () => null,
+}));
+vi.mock('./create-board-modal', () => ({
+  CreateBoardModal: () => null,
 }));
 vi.mock('../profile/profile-dialog', () => ({
   ProfileDialog: () => <div data-testid="profile-dialog" />,
@@ -102,7 +111,7 @@ describe('KanbanBoard empty/welcome state (Issue #11)', () => {
         id: '1', title: 'Task', description: '', status: 'To Do',
         owner: '', due_date: '', scheduled_date: '', labels: '',
         parent_id: '', created_at: '', updated_at: '', completed_at: '',
-        sort_order: 1, created_by: '', sheetRow: 2,
+        sort_order: 1, created_by: '', board_id: '', sheetRow: 2,
       }];
       const { container } = renderBoard();
       const welcome = container.querySelector('[data-testid="board-welcome"]');
@@ -124,7 +133,7 @@ describe('KanbanBoard empty/welcome state (Issue #11)', () => {
         id: '1', title: 'Task', description: '', status: 'To Do',
         owner: '', due_date: '', scheduled_date: '', labels: '',
         parent_id: '', created_at: '', updated_at: '', completed_at: '',
-        sort_order: 1, created_by: '', sheetRow: 2,
+        sort_order: 1, created_by: '', board_id: '', sheetRow: 2,
       }];
       const { container } = renderBoard();
       // Board should show columns, not welcome

--- a/frontend/src/components/board/kanban-board.tsx
+++ b/frontend/src/components/board/kanban-board.tsx
@@ -1,11 +1,13 @@
 import { useState, useRef, useCallback } from 'preact/hooks';
 import { useAuth } from '../../auth/auth-context';
-import { columns, showCreateModal, selectedItem, groupBy, rootItems, items, owners, labels as labelsStore, viewMode, setViewMode, allDoneItems, hasArchivedItems, showArchiveDialog } from '../../state/board-store';
+import { columns, showCreateModal, selectedItem, groupBy, rootItems, items, owners, labels as labelsStore, viewMode, setViewMode, allDoneItems, hasArchivedItems, showArchiveDialog, boards, showCreateBoardModal, boardItems } from '../../state/board-store';
 import { moveItem } from '../../state/actions';
 import { Column } from './column';
 import { ListView } from './list-view';
 import { CardDetail } from './card-detail';
 import { CreateItemModal } from '../forms/create-item-modal';
+import { CreateBoardModal } from './create-board-modal';
+import { BoardSwitcher } from './board-switcher';
 import { ProfileDialog } from '../profile/profile-dialog';
 import { ArchiveDialog } from '../archive/archive-dialog';
 import { FilterBar } from '../filters/filter-bar';
@@ -44,8 +46,8 @@ export function KanbanBoard() {
     }
   };
 
-  // Check if the entire board is empty (zero items total, ignoring filters)
-  const isBoardEmpty = items.value.length === 0;
+  // Check if the current board is empty (zero items for this board, ignoring filters)
+  const isBoardEmpty = boardItems.value.length === 0;
 
   // Swimlane grouping
   const renderSwimlanes = () => {
@@ -132,6 +134,8 @@ export function KanbanBoard() {
         </div>
       </header>
 
+      {boards.value.length > 0 && <BoardSwitcher />}
+
       <FilterBar />
 
       <div class="view-toggle-bar" data-testid="view-toggle-bar">
@@ -178,6 +182,7 @@ export function KanbanBoard() {
 
       {selectedItem.value && <CardDetail />}
       {showCreateModal.value && <CreateItemModal />}
+      {showCreateBoardModal.value && <CreateBoardModal />}
       {showArchiveDialog.value && <ArchiveDialog onClose={handleCloseArchive} />}
       {showProfile && user && token && (
         <ProfileDialog

--- a/frontend/src/components/board/list-view.test.tsx
+++ b/frontend/src/components/board/list-view.test.tsx
@@ -41,6 +41,7 @@ function makeItem(overrides: Partial<ItemWithRow> = {}): ItemWithRow {
     completed_at: '',
     sort_order: 1,
     created_by: '',
+    board_id: '',
     sheetRow: 2,
     ...overrides,
   };

--- a/frontend/src/components/board/view-toggle.test.tsx
+++ b/frontend/src/components/board/view-toggle.test.tsx
@@ -39,10 +39,21 @@ vi.mock('../../state/board-store', () => ({
   allDoneItems: { value: [] },
   hasArchivedItems: { value: false },
   showArchiveDialog: { value: false },
+  boards: { value: [] },
+  boardItems: { get value() { return mockItemsRef.current; } },
+  showCreateBoardModal: { value: false },
 }));
 
 vi.mock('../../state/actions', () => ({
   moveItem: vi.fn(),
+}));
+
+vi.mock('./board-switcher', () => ({
+  BoardSwitcher: () => null,
+}));
+
+vi.mock('./create-board-modal', () => ({
+  CreateBoardModal: () => null,
 }));
 
 vi.mock('../filters/filter-bar', () => ({
@@ -99,7 +110,7 @@ describe('View Toggle (Issue #13)', () => {
         id: '1', title: 'Task A', description: '', status: 'To Do',
         owner: '', due_date: '', scheduled_date: '', labels: '',
         parent_id: '', created_at: '', updated_at: '', completed_at: '',
-        sort_order: 1, created_by: '', sheetRow: 2,
+        sort_order: 1, created_by: '', board_id: '', sheetRow: 2,
       },
     ];
   });

--- a/frontend/src/demo/mock-api.test.ts
+++ b/frontend/src/demo/mock-api.test.ts
@@ -52,6 +52,7 @@ describe('Mock API layer (AC5)', () => {
       completed_at: '',
       sort_order: 100,
       created_by: 'test@example.com',
+      board_id: '',
     };
     await createItemRow(newItem, 'demo-token');
     const after = await fetchAllItems('demo-token');
@@ -107,6 +108,7 @@ describe('Mock API layer (AC5)', () => {
       id: 'test-http', title: 'Test', description: '', status: 'To Do',
       owner: '', due_date: '', scheduled_date: '', labels: '', parent_id: '',
       created_at: '', updated_at: '', completed_at: '', sort_order: 0, created_by: '',
+      board_id: '',
     };
     await createItemRow(newItem, 'demo-token');
     await updateItemRow(2, newItem, 'demo-token');

--- a/frontend/src/demo/mock-api.ts
+++ b/frontend/src/demo/mock-api.ts
@@ -3,19 +3,21 @@
 // entirely in-memory using @preact/signals. No HTTP requests are made.
 
 import { signal } from '@preact/signals';
-import type { Item, ItemWithRow, Owner, Label } from '../api/types';
-import { MOCK_ITEMS, MOCK_OWNERS, MOCK_LABELS } from './mock-data';
+import type { Item, ItemWithRow, Owner, Label, Board } from '../api/types';
+import { MOCK_ITEMS, MOCK_OWNERS, MOCK_LABELS, MOCK_BOARDS } from './mock-data';
 
 // In-memory state — deep-clone from static data so writes don't mutate the originals.
 const mockItemsState = signal<ItemWithRow[]>(structuredClone(MOCK_ITEMS));
 const mockLabelsState = signal<Array<Label & { sheetRow: number }>>(
   structuredClone(MOCK_LABELS).map((l, i) => ({ ...l, sheetRow: i + 2 }))
 );
+const mockBoardsState = signal<Board[]>(structuredClone(MOCK_BOARDS));
 
 /** Reset in-memory state back to the original mock data (for page refresh behavior). */
 export function resetMockState(): void {
   mockItemsState.value = structuredClone(MOCK_ITEMS);
   mockLabelsState.value = structuredClone(MOCK_LABELS).map((l, i) => ({ ...l, sheetRow: i + 2 }));
+  mockBoardsState.value = structuredClone(MOCK_BOARDS);
 }
 
 // --- Read operations ---
@@ -121,4 +123,14 @@ export async function cascadeLabelUpdate(
     }
     return { ...item, labels: updated.join(', ') };
   });
+}
+
+// --- Board operations (in-memory) ---
+
+export async function fetchBoards(_token: string): Promise<Board[]> {
+  return mockBoardsState.value;
+}
+
+export async function createBoardRow(board: Board, _token: string): Promise<void> {
+  mockBoardsState.value = [...mockBoardsState.value, board];
 }

--- a/frontend/src/demo/mock-data.ts
+++ b/frontend/src/demo/mock-data.ts
@@ -2,7 +2,7 @@
 // Covers all board features: multiple statuses, owners, labels,
 // subtasks, overdue dates, scheduled dates, long titles, unassigned items.
 
-import type { ItemWithRow, Owner, Label } from '../api/types';
+import type { ItemWithRow, Owner, Label, Board } from '../api/types';
 
 // Helper to produce ISO date strings relative to "now" at module load time.
 // Using a fixed reference keeps data deterministic within a single page load.
@@ -35,6 +35,12 @@ export const MOCK_LABELS: Label[] = [
   { label: 'Fun', color: '#26c6da' },
 ];
 
+// --- Boards ---
+export const MOCK_BOARDS: Board[] = [
+  { id: 'board-family', name: 'Family Board', created_at: daysAgo(30), created_by: 'mom@family.com' },
+  { id: 'board-work', name: 'Work Projects', created_at: daysAgo(14), created_by: 'dad@family.com' },
+];
+
 // --- Items ---
 // IDs are static UUIDs for reproducibility.
 export const MOCK_ITEMS: ItemWithRow[] = [
@@ -54,6 +60,7 @@ export const MOCK_ITEMS: ItemWithRow[] = [
     completed_at: '',
     sort_order: 1,
     created_by: 'mom@family.com',
+    board_id: 'board-family',
     sheetRow: 2,
   },
   // Subtask 1a: Buy vegetables — Done
@@ -72,6 +79,7 @@ export const MOCK_ITEMS: ItemWithRow[] = [
     completed_at: daysAgo(2),
     sort_order: 1,
     created_by: 'mom@family.com',
+    board_id: 'board-family',
     sheetRow: 3,
   },
   // Subtask 1b: Buy cleaning supplies — Done
@@ -90,6 +98,7 @@ export const MOCK_ITEMS: ItemWithRow[] = [
     completed_at: daysAgo(2),
     sort_order: 2,
     created_by: 'mom@family.com',
+    board_id: 'board-family',
     sheetRow: 4,
   },
   // Subtask 1c: Pick up prescription — To Do, assigned to Dad
@@ -108,6 +117,7 @@ export const MOCK_ITEMS: ItemWithRow[] = [
     completed_at: '',
     sort_order: 3,
     created_by: 'mom@family.com',
+    board_id: 'board-family',
     sheetRow: 5,
   },
 
@@ -127,6 +137,7 @@ export const MOCK_ITEMS: ItemWithRow[] = [
     completed_at: '',
     sort_order: 1,
     created_by: 'dad@family.com',
+    board_id: 'board-family',
     sheetRow: 6,
   },
 
@@ -146,6 +157,7 @@ export const MOCK_ITEMS: ItemWithRow[] = [
     completed_at: '',
     sort_order: 2,
     created_by: 'kiddo@family.com',
+    board_id: 'board-family',
     sheetRow: 7,
   },
 
@@ -165,6 +177,7 @@ export const MOCK_ITEMS: ItemWithRow[] = [
     completed_at: '',
     sort_order: 2,
     created_by: 'mom@family.com',
+    board_id: 'board-family',
     sheetRow: 8,
   },
 
@@ -184,6 +197,7 @@ export const MOCK_ITEMS: ItemWithRow[] = [
     completed_at: daysAgo(7),
     sort_order: 1,
     created_by: 'dad@family.com',
+    board_id: 'board-family',
     sheetRow: 9,
   },
 
@@ -203,6 +217,7 @@ export const MOCK_ITEMS: ItemWithRow[] = [
     completed_at: '',
     sort_order: 3,
     created_by: 'mom@family.com',
+    board_id: 'board-family',
     sheetRow: 10,
   },
 
@@ -222,6 +237,7 @@ export const MOCK_ITEMS: ItemWithRow[] = [
     completed_at: '',
     sort_order: 4,
     created_by: 'kiddo@family.com',
+    board_id: 'board-family',
     sheetRow: 11,
   },
 
@@ -241,6 +257,7 @@ export const MOCK_ITEMS: ItemWithRow[] = [
     completed_at: '',
     sort_order: 3,
     created_by: 'mom@family.com',
+    board_id: 'board-work',
     sheetRow: 12,
   },
 
@@ -260,6 +277,7 @@ export const MOCK_ITEMS: ItemWithRow[] = [
     completed_at: daysAgo(30),
     sort_order: 2,
     created_by: 'dad@family.com',
+    board_id: 'board-family',
     sheetRow: 13,
   },
 
@@ -279,6 +297,7 @@ export const MOCK_ITEMS: ItemWithRow[] = [
     completed_at: daysAgo(2),
     sort_order: 3,
     created_by: 'mom@family.com',
+    board_id: 'board-family',
     sheetRow: 17,
   },
 
@@ -298,6 +317,7 @@ export const MOCK_ITEMS: ItemWithRow[] = [
     completed_at: '',
     sort_order: 5,
     created_by: 'dad@family.com',
+    board_id: 'board-family',
     sheetRow: 14,
   },
 
@@ -317,6 +337,7 @@ export const MOCK_ITEMS: ItemWithRow[] = [
     completed_at: '',
     sort_order: 6,
     created_by: 'kiddo@family.com',
+    board_id: 'board-family',
     sheetRow: 15,
   },
 
@@ -336,6 +357,7 @@ export const MOCK_ITEMS: ItemWithRow[] = [
     completed_at: '',
     sort_order: 4,
     created_by: 'mom@family.com',
+    board_id: 'board-work',
     sheetRow: 16,
   },
 ];

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -537,6 +537,48 @@ body {
   white-space: nowrap;
 }
 
+/* === Board Switcher === */
+.board-switcher {
+  display: flex;
+  align-items: center;
+  padding: 8px 20px;
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
+  flex-shrink: 0;
+}
+
+.board-switcher-select {
+  padding: 6px 12px;
+  border: 2px solid var(--color-primary);
+  border-radius: var(--radius);
+  font-size: 14px;
+  font-weight: 600;
+  font-family: inherit;
+  color: var(--color-primary);
+  background: var(--color-surface);
+  cursor: pointer;
+  min-height: 36px;
+}
+
+.board-switcher-select:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+}
+
+/* Board name meta row (error + char counter) */
+.board-name-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-top: 2px;
+  min-height: 18px;
+}
+
+.form-error {
+  font-size: 12px;
+  color: var(--color-danger);
+}
+
 /* === Filter Bar === */
 .filter-bar {
   display: flex;
@@ -1538,6 +1580,12 @@ body {
   .board-main:has(.list-view) {
     overflow-x: hidden;
     overflow-y: auto;
+  }
+
+  /* Board switcher: touch-friendly on mobile */
+  .board-switcher-select {
+    min-height: 44px;
+    font-size: 16px;
   }
 
   /* AC1: Filter selects have proper touch targets on mobile */

--- a/frontend/src/state/actions.test.ts
+++ b/frontend/src/state/actions.test.ts
@@ -17,6 +17,8 @@ vi.mock('../api/sheets', () => ({
   cascadeLabelUpdate: vi.fn().mockResolvedValue(undefined),
   cascadeOwnerUpdate: vi.fn().mockResolvedValue(undefined),
   upsertOwner: vi.fn().mockResolvedValue(false),
+  fetchBoards: vi.fn().mockResolvedValue([]),
+  createBoardRow: vi.fn().mockResolvedValue(undefined),
   SheetsApiError: class extends Error {
     status: number;
     constructor(status: number, message: string) {
@@ -47,6 +49,8 @@ vi.mock('../demo/mock-api', () => ({
   cascadeLabelUpdate: vi.fn().mockResolvedValue(undefined),
   cascadeOwnerUpdate: vi.fn().mockResolvedValue(undefined),
   upsertOwner: vi.fn().mockResolvedValue(false),
+  fetchBoards: vi.fn().mockResolvedValue([]),
+  createBoardRow: vi.fn().mockResolvedValue(undefined),
 }));
 
 import { loadBoard, NotAllowedError, deleteSubtask, reorderSubtasks } from './actions';
@@ -129,6 +133,7 @@ function makeItem(overrides: Partial<ItemWithRow> = {}): ItemWithRow {
     completed_at: '',
     sort_order: 1,
     created_by: 'luke@example.com',
+    board_id: '',
     sheetRow: 2,
     ...overrides,
   };

--- a/frontend/src/state/actions.ts
+++ b/frontend/src/state/actions.ts
@@ -1,4 +1,4 @@
-import { items, showToast } from './board-store';
+import { items, showToast, boards, activeBoardId, initActiveBoardFromUrl } from './board-store';
 import { validateStatusTransition, applyStatusSideEffects } from './rules';
 import {
   fetchAllItems as sheetsFetchAllItems,
@@ -15,6 +15,8 @@ import {
   cascadeLabelUpdate as sheetsCascadeLabelUpdate,
   cascadeOwnerUpdate as sheetsCascadeOwnerUpdate,
   upsertOwner as sheetsUpsertOwner,
+  fetchBoards as sheetsFetchBoards,
+  createBoardRow as sheetsCreateBoardRow,
 } from '../api/sheets';
 import {
   fetchAllItems as mockFetchAllItems,
@@ -31,6 +33,8 @@ import {
   cascadeLabelUpdate as mockCascadeLabelUpdate,
   cascadeOwnerUpdate as mockCascadeOwnerUpdate,
   upsertOwner as mockUpsertOwner,
+  fetchBoards as mockFetchBoards,
+  createBoardRow as mockCreateBoardRow,
 } from '../demo/mock-api';
 import { isDemoMode } from '../demo/is-demo-mode';
 import { ReauthFailedError } from '../auth/reauth';
@@ -66,6 +70,8 @@ function api() {
       cascadeLabelUpdate: mockCascadeLabelUpdate,
       cascadeOwnerUpdate: mockCascadeOwnerUpdate,
       upsertOwner: mockUpsertOwner,
+      fetchBoards: mockFetchBoards,
+      createBoardRow: mockCreateBoardRow,
     };
   }
   return {
@@ -83,6 +89,8 @@ function api() {
     cascadeLabelUpdate: sheetsCascadeLabelUpdate,
     cascadeOwnerUpdate: sheetsCascadeOwnerUpdate,
     upsertOwner: sheetsUpsertOwner,
+    fetchBoards: sheetsFetchBoards,
+    createBoardRow: sheetsCreateBoardRow,
   };
 }
 
@@ -100,6 +108,8 @@ const fetchLabelsWithRows = (...args: Parameters<typeof sheetsFetchLabelsWithRow
 const cascadeLabelUpdate = (...args: Parameters<typeof sheetsCascadeLabelUpdate>) => api().cascadeLabelUpdate(...args);
 const cascadeOwnerUpdate = (...args: Parameters<typeof sheetsCascadeOwnerUpdate>) => api().cascadeOwnerUpdate(...args);
 const upsertOwner = (...args: Parameters<typeof sheetsUpsertOwner>) => api().upsertOwner(...args);
+const fetchBoardsApi = (...args: Parameters<typeof sheetsFetchBoards>) => api().fetchBoards(...args);
+const createBoardRowApi = (...args: Parameters<typeof sheetsCreateBoardRow>) => api().createBoardRow(...args);
 
 function generateUUID(): string {
   return crypto.randomUUID();
@@ -116,14 +126,21 @@ export class NotAllowedError extends Error {
 export async function loadBoard(token: string, user?: UserInfo | null) {
   loading.value = true;
   try {
-    const [itemsData, ownersData, labelsData] = await Promise.all([
+    const [itemsData, ownersData, labelsData, boardsData] = await Promise.all([
       fetchAllItems(token),
       fetchOwners(token),
       fetchLabels(token),
+      fetchBoardsApi(token),
     ]);
     items.value = itemsData;
     owners.value = ownersData;
     labels.value = labelsData;
+    boards.value = boardsData;
+
+    // Initialize active board from URL or default to first board
+    if (boardsData.length > 0) {
+      initActiveBoardFromUrl();
+    }
 
     // Allowlist check: the Owners sheet is the source of truth for who can
     // use the board. If the signed-in user's email isn't listed, reject.
@@ -191,6 +208,7 @@ export async function createItem(
     completed_at: status === 'Done' ? now : '',
     sort_order: maxOrder + 1,
     created_by: data.created_by || '',
+    board_id: data.board_id || activeBoardId.value,
   };
 
   // Optimistic update
@@ -571,5 +589,48 @@ export async function deleteLabel(
     if (!isReauthFailure(err)) {
       showToast('Failed to delete label: ' + err.message, 'error');
     }
+  }
+}
+
+// --- Board actions ---
+
+import type { Board } from '../api/types';
+import { switchBoard } from './board-store';
+
+export async function createBoard(
+  name: string,
+  actor: string,
+  token: string
+): Promise<boolean> {
+  const trimmed = name.trim();
+  if (!trimmed) return false;
+  if (trimmed.length > 30) return false;
+
+  // Check for duplicate name
+  if (boards.value.some(b => b.name.toLowerCase() === trimmed.toLowerCase())) {
+    return false;
+  }
+
+  const board: Board = {
+    id: generateUUID(),
+    name: trimmed,
+    created_at: new Date().toISOString(),
+    created_by: actor,
+  };
+
+  // Optimistic update
+  boards.value = [...boards.value, board];
+
+  try {
+    await createBoardRowApi(board, token);
+    switchBoard(board.id);
+    showToast('Board created');
+    return true;
+  } catch (err: any) {
+    boards.value = boards.value.filter(b => b.id !== board.id);
+    if (!isReauthFailure(err)) {
+      showToast('Failed to create board: ' + err.message, 'error');
+    }
+    return false;
   }
 }

--- a/frontend/src/state/board-store-boards.test.ts
+++ b/frontend/src/state/board-store-boards.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import type { ItemWithRow, Board } from '../api/types';
+
+function makeItem(overrides: Partial<ItemWithRow>): ItemWithRow {
+  return {
+    id: 'test-' + Math.random().toString(36).slice(2),
+    title: 'Test Item',
+    description: '',
+    status: 'To Do',
+    owner: 'Mom',
+    due_date: '',
+    scheduled_date: '',
+    labels: '',
+    parent_id: '',
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    completed_at: '',
+    sort_order: 1,
+    created_by: 'test@test.com',
+    board_id: 'board-1',
+    sheetRow: 2,
+    ...overrides,
+  };
+}
+
+describe('AC2: Items scoped to a board', () => {
+  it('boardItems returns only items for the active board', async () => {
+    const { items, boards, activeBoardId, boardItems } = await import('./board-store');
+
+    boards.value = [
+      { id: 'board-1', name: 'Family', created_at: '', created_by: '' },
+      { id: 'board-2', name: 'Work', created_at: '', created_by: '' },
+    ];
+    activeBoardId.value = 'board-1';
+
+    items.value = [
+      makeItem({ id: 'a', board_id: 'board-1' }),
+      makeItem({ id: 'b', board_id: 'board-2' }),
+      makeItem({ id: 'c', board_id: 'board-1' }),
+    ];
+
+    expect(boardItems.value.map(i => i.id)).toEqual(['a', 'c']);
+  });
+
+  it('boardItems includes children whose parent is on the active board', async () => {
+    const { items, boards, activeBoardId, boardItems } = await import('./board-store');
+
+    boards.value = [{ id: 'board-1', name: 'Family', created_at: '', created_by: '' }];
+    activeBoardId.value = 'board-1';
+
+    items.value = [
+      makeItem({ id: 'parent', board_id: 'board-1', parent_id: '' }),
+      makeItem({ id: 'child', board_id: 'board-1', parent_id: 'parent' }),
+    ];
+
+    expect(boardItems.value.map(i => i.id)).toEqual(['parent', 'child']);
+  });
+
+  it('returns all items when no active board is set', async () => {
+    const { items, activeBoardId, boardItems } = await import('./board-store');
+
+    activeBoardId.value = '';
+    items.value = [
+      makeItem({ id: 'a', board_id: 'board-1' }),
+      makeItem({ id: 'b', board_id: 'board-2' }),
+    ];
+
+    expect(boardItems.value.length).toBe(2);
+  });
+});
+
+describe('AC3: switchBoard resets filters but not view mode', () => {
+  it('resets filters and selection when switching boards', async () => {
+    const { boards, activeBoardId, filterOwner, filterLabel, selectedItemId, switchBoard } = await import('./board-store');
+
+    boards.value = [
+      { id: 'board-1', name: 'Family', created_at: '', created_by: '' },
+      { id: 'board-2', name: 'Work', created_at: '', created_by: '' },
+    ];
+    activeBoardId.value = 'board-1';
+    filterOwner.value = 'Mom';
+    filterLabel.value = 'Home';
+    selectedItemId.value = 'some-item';
+
+    switchBoard('board-2');
+
+    expect(activeBoardId.value).toBe('board-2');
+    expect(filterOwner.value).toBeNull();
+    expect(filterLabel.value).toBeNull();
+    expect(selectedItemId.value).toBeNull();
+  });
+
+  it('does NOT reset view mode when switching boards', async () => {
+    const { boards, activeBoardId, viewMode, setViewMode, switchBoard } = await import('./board-store');
+
+    boards.value = [
+      { id: 'board-1', name: 'Family', created_at: '', created_by: '' },
+      { id: 'board-2', name: 'Work', created_at: '', created_by: '' },
+    ];
+    activeBoardId.value = 'board-1';
+    setViewMode('list');
+
+    switchBoard('board-2');
+
+    expect(viewMode.value).toBe('list');
+  });
+
+  it('updates document title when switching boards', async () => {
+    const { boards, activeBoardId, switchBoard } = await import('./board-store');
+
+    boards.value = [
+      { id: 'board-1', name: 'Family Board', created_at: '', created_by: '' },
+      { id: 'board-2', name: 'Work Projects', created_at: '', created_by: '' },
+    ];
+    activeBoardId.value = 'board-1';
+
+    switchBoard('board-2');
+
+    expect(document.title).toBe('Hive \u2014 Work Projects');
+  });
+});
+
+describe('AC3: initActiveBoardFromUrl reads board from URL', () => {
+  afterEach(() => {
+    // Reset URL
+    window.history.replaceState(null, '', window.location.pathname);
+  });
+
+  it('selects board from URL ?board= param', async () => {
+    const { boards, activeBoardId, initActiveBoardFromUrl } = await import('./board-store');
+
+    boards.value = [
+      { id: 'board-1', name: 'Family', created_at: '', created_by: '' },
+      { id: 'board-2', name: 'Work', created_at: '', created_by: '' },
+    ];
+
+    window.history.replaceState(null, '', '?board=board-2');
+    initActiveBoardFromUrl();
+
+    expect(activeBoardId.value).toBe('board-2');
+  });
+
+  it('falls back to first board when URL param is invalid', async () => {
+    const { boards, activeBoardId, initActiveBoardFromUrl } = await import('./board-store');
+
+    boards.value = [
+      { id: 'board-1', name: 'Family', created_at: '', created_by: '' },
+      { id: 'board-2', name: 'Work', created_at: '', created_by: '' },
+    ];
+
+    window.history.replaceState(null, '', '?board=nonexistent');
+    initActiveBoardFromUrl();
+
+    expect(activeBoardId.value).toBe('board-1');
+  });
+});
+
+describe('activeBoard computed', () => {
+  it('returns the currently active board object', async () => {
+    const { boards, activeBoardId, activeBoard } = await import('./board-store');
+
+    boards.value = [
+      { id: 'board-1', name: 'Family', created_at: '', created_by: '' },
+      { id: 'board-2', name: 'Work', created_at: '', created_by: '' },
+    ];
+    activeBoardId.value = 'board-2';
+
+    expect(activeBoard.value?.name).toBe('Work');
+  });
+
+  it('returns null when no board matches', async () => {
+    const { boards, activeBoardId, activeBoard } = await import('./board-store');
+
+    boards.value = [];
+    activeBoardId.value = 'nonexistent';
+
+    expect(activeBoard.value).toBeNull();
+  });
+});

--- a/frontend/src/state/board-store.test.ts
+++ b/frontend/src/state/board-store.test.ts
@@ -17,6 +17,7 @@ function makeItem(overrides: Partial<ItemWithRow>): ItemWithRow {
     completed_at: new Date().toISOString(),
     sort_order: 1,
     created_by: 'test@test.com',
+    board_id: '',
     sheetRow: 2,
     ...overrides,
   };

--- a/frontend/src/state/board-store.ts
+++ b/frontend/src/state/board-store.ts
@@ -1,11 +1,31 @@
 import { signal, computed } from '@preact/signals';
-import type { ItemWithRow, Owner, Label, ItemStatus } from '../api/types';
+import type { ItemWithRow, Owner, Label, ItemStatus, Board } from '../api/types';
 
 // --- Core data ---
 export const items = signal<ItemWithRow[]>([]);
 export const owners = signal<Owner[]>([]);
 export const labels = signal<Label[]>([]);
+export const boards = signal<Board[]>([]);
+export const activeBoardId = signal<string>('');
 export const loading = signal(true);
+
+/** The currently active board object. */
+export const activeBoard = computed(() =>
+  boards.value.find(b => b.id === activeBoardId.value) ?? null
+);
+
+/** Items scoped to the active board (plus their children). */
+export const boardItems = computed(() => {
+  const bid = activeBoardId.value;
+  if (!bid) return items.value;
+  // Include items on this board, plus children whose parent is on this board
+  const boardRoots = new Set(
+    items.value.filter(i => i.board_id === bid && !i.parent_id).map(i => i.id)
+  );
+  return items.value.filter(i =>
+    (i.board_id === bid) || (i.parent_id && boardRoots.has(i.parent_id))
+  );
+});
 
 // --- Filters ---
 export const filterOwner = signal<string | null>(null);
@@ -40,7 +60,7 @@ export function setViewMode(mode: ViewMode) {
 
 // --- Derived ---
 export const filteredItems = computed(() => {
-  let result = items.value;
+  let result = boardItems.value;
 
   if (filterOwner.value) {
     result = result.filter(i => i.owner === filterOwner.value);
@@ -93,6 +113,45 @@ export const allDoneItemsSorted = computed(() =>
 
 // --- UI state for archive dialog ---
 export const showArchiveDialog = signal(false);
+
+// --- UI state for board creation ---
+export const showCreateBoardModal = signal(false);
+
+/** Switch to a different board. Resets filters and selection but preserves view mode. */
+export function switchBoard(boardId: string) {
+  activeBoardId.value = boardId;
+  filterOwner.value = null;
+  filterLabel.value = null;
+  groupBy.value = 'none';
+  selectedItemId.value = null;
+
+  // Update URL with board param
+  const url = new URL(window.location.href);
+  url.searchParams.set('board', boardId);
+  window.history.replaceState(null, '', url.toString());
+
+  // Update document title
+  const board = boards.value.find(b => b.id === boardId);
+  if (board) {
+    document.title = `Hive \u2014 ${board.name}`;
+  }
+}
+
+/** Read active board from URL query param, falling back to first board. */
+export function initActiveBoardFromUrl() {
+  const params = new URLSearchParams(window.location.search);
+  const boardParam = params.get('board');
+  if (boardParam && boards.value.some(b => b.id === boardParam)) {
+    activeBoardId.value = boardParam;
+  } else if (boards.value.length > 0) {
+    activeBoardId.value = boards.value[0].id;
+  }
+  // Update document title
+  const board = boards.value.find(b => b.id === activeBoardId.value);
+  if (board) {
+    document.title = `Hive \u2014 ${board.name}`;
+  }
+}
 
 export const columns = computed(() => ({
   'To Do': rootItems.value.filter(i => i.status === 'To Do').sort(bySortOrder),


### PR DESCRIPTION
## Summary
Add support for multiple boards so families can organize tasks into separate workspaces (e.g., "Family Board", "Work Projects"). Each board has its own items, with a board switcher in the header and a create-board modal.

Closes #41

## Changes
- **`frontend/src/api/types.ts`** — Added `Board` interface; added `board_id` to `Item`
- **`frontend/src/api/sheets.ts`** — Extended Items column range A:N → A:O for board_id; added `fetchBoards()` and `createBoardRow()` for Boards tab
- **`frontend/src/demo/mock-data.ts`** — Added `MOCK_BOARDS` with 2 demo boards; added `board_id` to all 16 mock items
- **`frontend/src/demo/mock-api.ts`** — Added `mockBoardsState`, `fetchBoards()`, `createBoardRow()` for demo mode
- **`frontend/src/state/board-store.ts`** — Added `boards`, `activeBoardId`, `activeBoard`, `boardItems` signals/computed; added `switchBoard()` (resets filters, updates URL and title), `initActiveBoardFromUrl()`, `showCreateBoardModal`
- **`frontend/src/state/actions.ts`** — Updated `loadBoard()` to fetch boards and init from URL; updated `createItem()` to include `board_id`; added `createBoard()` action
- **`frontend/src/components/board/board-switcher.tsx`** — New component: select dropdown with boards and "New Board..." option
- **`frontend/src/components/board/create-board-modal.tsx`** — New component: modal with name input, validation (empty/duplicate/30-char), focus management, Escape to close
- **`frontend/src/components/board/kanban-board.tsx`** — Integrated BoardSwitcher and CreateBoardModal; scoped empty state to `boardItems`
- **`frontend/src/global.css`** — Added board-switcher styles with mobile responsive rules (44px touch targets)
- **13 test files** — Added `board_id` field to all item fixtures and updated mocks

## Testing
- AC1 (Board registry): Board type defined, Sheets API reads Boards tab, demo mode provides mock boards
- AC2 (Items scoped to board): `boardItems` computed filters by `activeBoardId`, includes children
- AC3 (Board switcher): `switchBoard()` resets filters/selection but not view mode, updates URL and document title, `initActiveBoardFromUrl()` reads `?board=` param
- AC4 (Create board): Modal validates name, prevents duplicates, focuses input on open
- AC5 (Empty board state): Welcome message shown when board has zero items
- AC6 (Demo mode): Mock boards loaded in demo mode

### Tests added
- `board-store-boards.test.ts` — 10 tests covering boardItems scoping, switchBoard, URL init, activeBoard computed

## Rules Sync
- [x] Business rules in `frontend/src/state/rules.ts` updated (if applicable) — N/A, no rule changes
- [x] Business rules in `apps-script/src/rules.js` updated (if applicable) — N/A
- [x] Both files remain in sync