### PR TITLE
fix: prevent focus trap from stealing focus on keystroke (#92)

### DIFF
--- a/frontend/src/components/board/share-modal.tsx
+++ b/frontend/src/components/board/share-modal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'preact/hooks';
+import { useState, useEffect, useRef, useCallback } from 'preact/hooks';
 import { useAuth } from '../../auth/auth-context';
 import { showShareModal, activeBoard, activeBoardId, permissions, owners } from '../../state/board-store';
 import { shareBoard, unshareBoard } from '../../state/actions';
@@ -25,12 +25,12 @@ export function ShareModal() {
     triggerRef.current = document.activeElement;
   }, []);
 
-  const close = () => {
+  const close = useCallback(() => {
     showShareModal.value = false;
     if (triggerRef.current instanceof HTMLElement) {
       triggerRef.current.focus();
     }
-  };
+  }, []);
 
   const containerRef = useFocusTrap(close);
 

--- a/frontend/src/hooks/use-focus-trap.test.tsx
+++ b/frontend/src/hooks/use-focus-trap.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, fireEvent, cleanup } from '@testing-library/preact';
+import { useState } from 'preact/hooks';
 import { useFocusTrap } from './use-focus-trap';
 
 afterEach(() => {
@@ -13,6 +14,24 @@ function TestHarness({ onEscape }: { onEscape?: () => void }) {
       <button data-testid="btn-first">First</button>
       <input data-testid="input-middle" type="text" />
       <button data-testid="btn-last">Last</button>
+    </div>
+  );
+}
+
+/** Harness that re-renders on input change (simulates the ShareModal bug) */
+function ReRenderHarness({ onEscape }: { onEscape?: () => void }) {
+  const [value, setValue] = useState('');
+  const ref = useFocusTrap(onEscape);
+  return (
+    <div ref={ref} data-testid="trap-container">
+      <button data-testid="btn-close">Close</button>
+      <input
+        data-testid="input-email"
+        type="text"
+        value={value}
+        onInput={(e) => setValue((e.target as HTMLInputElement).value)}
+      />
+      <button data-testid="btn-submit">Submit</button>
     </div>
   );
 }
@@ -81,5 +100,39 @@ describe('useFocusTrap', () => {
 
     // preventDefault should NOT be called because we're not on the last element
     expect(preventSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not steal focus from input when component re-renders (AC1)', () => {
+    const { getByTestId } = render(<ReRenderHarness onEscape={() => {}} />);
+    const emailInput = getByTestId('input-email');
+
+    // Focus the input (simulating user click)
+    emailInput.focus();
+    expect(document.activeElement).toBe(emailInput);
+
+    // Simulate typing which triggers re-render via state change
+    fireEvent.input(emailInput, { target: { value: 't' } });
+    expect(document.activeElement).toBe(emailInput);
+
+    fireEvent.input(emailInput, { target: { value: 'te' } });
+    expect(document.activeElement).toBe(emailInput);
+
+    fireEvent.input(emailInput, { target: { value: 'tes' } });
+    expect(document.activeElement).toBe(emailInput);
+  });
+
+  it('uses latest onEscape callback even after re-renders (AC3)', () => {
+    const onEscape1 = vi.fn();
+    const { getByTestId, rerender } = render(<TestHarness onEscape={onEscape1} />);
+    const container = getByTestId('trap-container');
+
+    // Re-render with a new callback
+    const onEscape2 = vi.fn();
+    rerender(<TestHarness onEscape={onEscape2} />);
+
+    // Press Escape — should call the latest callback
+    fireEvent.keyDown(container, { key: 'Escape' });
+    expect(onEscape1).not.toHaveBeenCalled();
+    expect(onEscape2).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/hooks/use-focus-trap.ts
+++ b/frontend/src/hooks/use-focus-trap.ts
@@ -10,12 +10,14 @@ const FOCUSABLE_SELECTOR =
  */
 export function useFocusTrap(onEscape?: () => void) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const onEscapeRef = useRef(onEscape);
+  onEscapeRef.current = onEscape;
 
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
 
-    // Focus the first focusable element within the container
+    // Focus the first focusable element within the container (once on mount)
     const focusableEls = container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
     if (focusableEls.length > 0) {
       focusableEls[0].focus();
@@ -24,7 +26,7 @@ export function useFocusTrap(onEscape?: () => void) {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         e.preventDefault();
-        onEscape?.();
+        onEscapeRef.current?.();
         return;
       }
 
@@ -53,7 +55,7 @@ export function useFocusTrap(onEscape?: () => void) {
 
     container.addEventListener('keydown', handleKeyDown);
     return () => container.removeEventListener('keydown', handleKeyDown);
-  }, [onEscape]);
+  }, []);
 
   return containerRef;
 }


### PR DESCRIPTION
## Summary
Fixes the share modal's add-person input losing focus on every keystroke. The focus trap hook was re-running its initial-focus logic on every render because the `onEscape` callback changed each time.

Closes #92

## Changes
- **`frontend/src/hooks/use-focus-trap.ts`** — Store `onEscape` in a ref instead of the effect dependency array. The effect now runs once on mount (empty deps), and the keydown handler reads the latest callback from the ref.
- **`frontend/src/components/board/share-modal.tsx`** — Memoize `close` with `useCallback` as a belt-and-suspenders measure. Added `useCallback` import.
- **`frontend/src/hooks/use-focus-trap.test.tsx`** — Added 2 test cases:
  - AC1: Verifies focus stays on input during re-renders caused by typing
  - AC3: Verifies the latest onEscape callback is called after re-renders

## Testing
- **AC1** (typing retains focus) → `use-focus-trap.test.tsx`: "does not steal focus from input when component re-renders"
- **AC2** (focus trap on open) → Existing test: "focuses the first focusable element on mount"
- **AC3** (Escape closes modal) → `use-focus-trap.test.tsx`: "uses latest onEscape callback even after re-renders"
- **AC4** (Tab cycling) → Existing tests: "wraps focus from last to first on Tab" + "wraps focus from first to last on Shift+Tab"

## Rules Sync
- [x] Business rules in `frontend/src/state/rules.ts` updated — N/A (no rule changes)
- [x] Business rules in `apps-script/src/rules.js` updated — N/A (no rule changes)
- [x] Both files remain in sync