### PR TITLE
feat: quick date shortcut chips (#82)

### DIFF
--- a/frontend/src/components/board/card-detail.tsx
+++ b/frontend/src/components/board/card-detail.tsx
@@ -8,6 +8,7 @@ import { LabelBadge } from '../shared/label-badge';
 import { LabelPickerManager } from '../labels/label-picker-manager';
 import { useFocusTrap } from '../../hooks/use-focus-trap';
 import { getContrastTextColor } from '../../utils/color';
+import { QuickDateChips } from '../shared/quick-date-chips';
 import type { ItemStatus } from '../../api/types';
 
 export function CardDetail() {
@@ -219,31 +220,49 @@ export function CardDetail() {
 
           <SaveFeedbackField label="Due Date">
             {(onFieldSaved) => (
-              <input
-                type="date"
-                value={item.due_date ? item.due_date.split('T')[0] : ''}
-                onChange={async (e) => {
-                  const prev = item.due_date ? item.due_date.split('T')[0] : '';
-                  const ok = await save('due_date', (e.target as HTMLInputElement).value);
-                  onFieldSaved(ok);
-                  if (!ok) (e.target as HTMLInputElement).value = prev;
-                }}
-              />
+              <>
+                <input
+                  type="date"
+                  value={item.due_date ? item.due_date.split('T')[0] : ''}
+                  onChange={async (e) => {
+                    const prev = item.due_date ? item.due_date.split('T')[0] : '';
+                    const ok = await save('due_date', (e.target as HTMLInputElement).value);
+                    onFieldSaved(ok);
+                    if (!ok) (e.target as HTMLInputElement).value = prev;
+                  }}
+                />
+                <QuickDateChips
+                  value={item.due_date ? item.due_date.split('T')[0] : ''}
+                  onChange={async (date) => {
+                    const ok = await save('due_date', date);
+                    onFieldSaved(ok);
+                  }}
+                />
+              </>
             )}
           </SaveFeedbackField>
 
           <SaveFeedbackField label="Scheduled Date">
             {(onFieldSaved) => (
-              <input
-                type="date"
-                value={item.scheduled_date ? item.scheduled_date.split('T')[0] : ''}
-                onChange={async (e) => {
-                  const prev = item.scheduled_date ? item.scheduled_date.split('T')[0] : '';
-                  const ok = await save('scheduled_date', (e.target as HTMLInputElement).value);
-                  onFieldSaved(ok);
-                  if (!ok) (e.target as HTMLInputElement).value = prev;
-                }}
-              />
+              <>
+                <input
+                  type="date"
+                  value={item.scheduled_date ? item.scheduled_date.split('T')[0] : ''}
+                  onChange={async (e) => {
+                    const prev = item.scheduled_date ? item.scheduled_date.split('T')[0] : '';
+                    const ok = await save('scheduled_date', (e.target as HTMLInputElement).value);
+                    onFieldSaved(ok);
+                    if (!ok) (e.target as HTMLInputElement).value = prev;
+                  }}
+                />
+                <QuickDateChips
+                  value={item.scheduled_date ? item.scheduled_date.split('T')[0] : ''}
+                  onChange={async (date) => {
+                    const ok = await save('scheduled_date', date);
+                    onFieldSaved(ok);
+                  }}
+                />
+              </>
             )}
           </SaveFeedbackField>
 

--- a/frontend/src/components/forms/create-item-modal.test.tsx
+++ b/frontend/src/components/forms/create-item-modal.test.tsx
@@ -383,7 +383,7 @@ describe('CreateItemModal — Inline Sub-tasks (Issue #55)', () => {
     });
   });
 
-  // AC9: Modal accessibility attributes
+  // AC9: Modal accessibility attributes (Issue #55)
   describe('AC9: Modal accessibility attributes', () => {
     it('modal has role="dialog" and aria-modal="true"', () => {
       const { container } = render(<CreateItemModal />);
@@ -404,6 +404,78 @@ describe('CreateItemModal — Inline Sub-tasks (Issue #55)', () => {
       const { container } = render(<CreateItemModal />);
       const closeBtn = container.querySelector('.modal-header .btn.btn-ghost') as HTMLButtonElement;
       expect(closeBtn.getAttribute('aria-label')).toBe('Close');
+    });
+  });
+});
+
+// --- Quick Date Shortcuts (Issue #82) ---
+describe('CreateItemModal — Quick Date Shortcuts (Issue #82)', () => {
+  describe('AC1: Quick date chips on create modal', () => {
+    it('renders quick date chips below the due date input', () => {
+      const { container } = render(<CreateItemModal />);
+      const dueDateField = container.querySelector('#due-date')!.closest('.form-field')!;
+      const chips = dueDateField.querySelector('.quick-date-chips');
+      expect(chips).not.toBeNull();
+      expect(chips!.querySelectorAll('.quick-date-chip')).toHaveLength(4);
+    });
+
+    it('renders quick date chips below the scheduled date input', () => {
+      const { container } = render(<CreateItemModal />);
+      const scheduledField = container.querySelector('#scheduled-date')!.closest('.form-field')!;
+      const chips = scheduledField.querySelector('.quick-date-chips');
+      expect(chips).not.toBeNull();
+      expect(chips!.querySelectorAll('.quick-date-chip')).toHaveLength(4);
+    });
+
+    it('tapping a due date chip populates the due date input', () => {
+      const { container } = render(<CreateItemModal />);
+      const dueDateField = container.querySelector('#due-date')!.closest('.form-field')!;
+      const todayChip = dueDateField.querySelector('.quick-date-chip') as HTMLButtonElement;
+      fireEvent.click(todayChip);
+
+      // Submitting the form should include today's date as due_date
+      const titleInput = container.querySelector('#title') as HTMLInputElement;
+      fireEvent.input(titleInput, { target: { value: 'Test' } });
+      const form = container.querySelector('form') as HTMLFormElement;
+      fireEvent.submit(form);
+
+      const today = new Date();
+      const expected = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
+      expect(mockCreateItem.mock.calls[0][0].due_date).toBe(expected);
+    });
+
+    it('tapping a scheduled date chip populates the scheduled date input', () => {
+      const { container } = render(<CreateItemModal />);
+      const scheduledField = container.querySelector('#scheduled-date')!.closest('.form-field')!;
+      const todayChip = scheduledField.querySelector('.quick-date-chip') as HTMLButtonElement;
+      fireEvent.click(todayChip);
+
+      const titleInput = container.querySelector('#title') as HTMLInputElement;
+      fireEvent.input(titleInput, { target: { value: 'Test' } });
+      const form = container.querySelector('form') as HTMLFormElement;
+      fireEvent.submit(form);
+
+      const today = new Date();
+      const expected = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
+      expect(mockCreateItem.mock.calls[0][0].scheduled_date).toBe(expected);
+    });
+
+    it('date input can still be edited manually after chip selection', () => {
+      const { container } = render(<CreateItemModal />);
+      const dueDateField = container.querySelector('#due-date')!.closest('.form-field')!;
+      const todayChip = dueDateField.querySelector('.quick-date-chip') as HTMLButtonElement;
+      fireEvent.click(todayChip);
+
+      // Override with manual date
+      const dueDateInput = container.querySelector('#due-date') as HTMLInputElement;
+      fireEvent.change(dueDateInput, { target: { value: '2026-12-25' } });
+
+      const titleInput = container.querySelector('#title') as HTMLInputElement;
+      fireEvent.input(titleInput, { target: { value: 'Test' } });
+      const form = container.querySelector('form') as HTMLFormElement;
+      fireEvent.submit(form);
+
+      expect(mockCreateItem.mock.calls[0][0].due_date).toBe('2026-12-25');
     });
   });
 });

--- a/frontend/src/components/forms/create-item-modal.tsx
+++ b/frontend/src/components/forms/create-item-modal.tsx
@@ -6,6 +6,7 @@ import type { StagedSubtask } from '../../state/actions';
 import { LabelPickerManager } from '../labels/label-picker-manager';
 import { useFocusTrap } from '../../hooks/use-focus-trap';
 import { getContrastTextColor } from '../../utils/color';
+import { QuickDateChips } from '../shared/quick-date-chips';
 
 export function CreateItemModal() {
   const { token, user } = useAuth();
@@ -134,6 +135,7 @@ export function CreateItemModal() {
                 value={dueDate}
                 onChange={(e) => setDueDate((e.target as HTMLInputElement).value)}
               />
+              <QuickDateChips value={dueDate} onChange={setDueDate} />
             </div>
 
             <div class="form-field">
@@ -144,6 +146,7 @@ export function CreateItemModal() {
                 value={scheduledDate}
                 onChange={(e) => setScheduledDate((e.target as HTMLInputElement).value)}
               />
+              <QuickDateChips value={scheduledDate} onChange={setScheduledDate} />
               <span class="form-hint">When you plan to do this</span>
             </div>
 

--- a/frontend/src/components/shared/quick-date-chips.test.tsx
+++ b/frontend/src/components/shared/quick-date-chips.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/preact';
+import { QuickDateChips } from './quick-date-chips';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('QuickDateChips — Issue #82', () => {
+  describe('AC1: Renders chip buttons', () => {
+    it('renders four quick date chips', () => {
+      const { container } = render(<QuickDateChips value="" onChange={() => {}} />);
+      const chips = container.querySelectorAll('.quick-date-chip');
+      expect(chips).toHaveLength(4);
+      expect(chips[0].textContent).toBe('Today');
+      expect(chips[1].textContent).toBe('This Fri');
+      expect(chips[2].textContent).toBe('Next Mon');
+      expect(chips[3].textContent).toBe('Next Month');
+    });
+
+    it('has a role="group" with accessible label', () => {
+      const { container } = render(<QuickDateChips value="" onChange={() => {}} />);
+      const group = container.querySelector('[role="group"]');
+      expect(group).not.toBeNull();
+      expect(group!.getAttribute('aria-label')).toBe('Quick date shortcuts');
+    });
+
+    it('chips have type="button" to prevent form submission', () => {
+      const { container } = render(<QuickDateChips value="" onChange={() => {}} />);
+      const chips = container.querySelectorAll('.quick-date-chip');
+      chips.forEach(chip => {
+        expect((chip as HTMLButtonElement).type).toBe('button');
+      });
+    });
+  });
+
+  describe('AC1: Tapping a chip populates the date', () => {
+    it('calls onChange with resolved date on click', () => {
+      const onChange = vi.fn();
+      const { container } = render(<QuickDateChips value="" onChange={onChange} />);
+      const todayChip = container.querySelector('.quick-date-chip') as HTMLButtonElement;
+      fireEvent.click(todayChip);
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      // Should be today's date in YYYY-MM-DD
+      const today = new Date();
+      const expected = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
+      expect(onChange).toHaveBeenCalledWith(expected);
+    });
+  });
+
+  describe('AC4: Active chip state', () => {
+    it('highlights the matching chip when value matches a shortcut', () => {
+      const today = new Date();
+      const value = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
+      const { container } = render(<QuickDateChips value={value} onChange={() => {}} />);
+
+      const activeChip = container.querySelector('.quick-date-chip-active');
+      expect(activeChip).not.toBeNull();
+      expect(activeChip!.textContent).toBe('Today');
+      expect(activeChip!.getAttribute('aria-pressed')).toBe('true');
+    });
+
+    it('no chip is active when value does not match any shortcut', () => {
+      const { container } = render(<QuickDateChips value="2099-12-25" onChange={() => {}} />);
+      const active = container.querySelector('.quick-date-chip-active');
+      expect(active).toBeNull();
+    });
+
+    it('non-active chips have aria-pressed="false"', () => {
+      const { container } = render(<QuickDateChips value="" onChange={() => {}} />);
+      const chips = container.querySelectorAll('.quick-date-chip');
+      chips.forEach(chip => {
+        expect(chip.getAttribute('aria-pressed')).toBe('false');
+      });
+    });
+
+    it('tapping active chip clears the date', () => {
+      const onChange = vi.fn();
+      const today = new Date();
+      const value = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
+      const { container } = render(<QuickDateChips value={value} onChange={onChange} />);
+
+      const activeChip = container.querySelector('.quick-date-chip-active') as HTMLButtonElement;
+      fireEvent.click(activeChip);
+
+      expect(onChange).toHaveBeenCalledWith('');
+    });
+  });
+});

--- a/frontend/src/components/shared/quick-date-chips.tsx
+++ b/frontend/src/components/shared/quick-date-chips.tsx
@@ -1,0 +1,38 @@
+import { DATE_SHORTCUTS, resolveDate, matchShortcut } from '../../utils/date-shortcuts';
+import type { DateShortcut } from '../../utils/date-shortcuts';
+
+interface QuickDateChipsProps {
+  /** Current date value in YYYY-MM-DD format */
+  value: string;
+  /** Called when a chip is tapped. Receives the resolved YYYY-MM-DD string, or '' to clear. */
+  onChange: (date: string) => void;
+}
+
+export function QuickDateChips({ value, onChange }: QuickDateChipsProps) {
+  const activeShortcut = matchShortcut(value);
+
+  const handleClick = (shortcut: DateShortcut) => {
+    if (activeShortcut === shortcut) {
+      // AC4: tapping active chip clears the date
+      onChange('');
+    } else {
+      onChange(resolveDate(shortcut));
+    }
+  };
+
+  return (
+    <div class="quick-date-chips" role="group" aria-label="Quick date shortcuts">
+      {DATE_SHORTCUTS.map(s => (
+        <button
+          key={s}
+          type="button"
+          class={`quick-date-chip${activeShortcut === s ? ' quick-date-chip-active' : ''}`}
+          aria-pressed={activeShortcut === s}
+          onClick={() => handleClick(s)}
+        >
+          {s}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -1817,6 +1817,50 @@ body {
   flex-wrap: wrap;
 }
 
+/* === Quick Date Chips (#82) === */
+.quick-date-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 2px;
+}
+
+.quick-date-chip {
+  padding: 4px 12px;
+  border: 1px solid var(--color-border);
+  border-radius: 14px;
+  background: transparent;
+  color: var(--color-text-secondary);
+  font-size: 12px;
+  cursor: pointer;
+  transition: all 0.15s;
+  white-space: nowrap;
+  font-family: inherit;
+}
+
+.quick-date-chip:hover {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+  background: color-mix(in srgb, var(--color-primary) 8%, transparent);
+}
+
+.quick-date-chip:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.quick-date-chip-active {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: white;
+}
+
+.quick-date-chip-active:hover {
+  background: var(--color-primary-hover);
+  border-color: var(--color-primary-hover);
+  color: white;
+}
+
 /* === Responsive === */
 @media (max-width: 768px) {
   .view-toggle-bar {
@@ -1909,6 +1953,13 @@ body {
   .share-input-row .btn-primary {
     min-height: 44px;
     min-width: 44px;
+  }
+
+  /* #82 AC5: Quick date chips meet 44px min touch target on mobile */
+  .quick-date-chip {
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
   }
 }
 

--- a/frontend/src/utils/date-shortcuts.test.ts
+++ b/frontend/src/utils/date-shortcuts.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { resolveDate, matchShortcut, DATE_SHORTCUTS } from './date-shortcuts';
+
+// Helper: create a Date from YYYY-MM-DD without timezone issues
+function d(s: string): Date {
+  const [y, m, dd] = s.split('-').map(Number);
+  return new Date(y, m - 1, dd);
+}
+
+describe('resolveDate — AC2: Date resolution logic', () => {
+  describe('Today', () => {
+    it('returns current date', () => {
+      expect(resolveDate('Today', d('2026-03-07'))).toBe('2026-03-07');
+    });
+  });
+
+  describe('This Fri', () => {
+    it('returns coming Friday when today is Monday', () => {
+      // 2026-03-02 is a Monday
+      expect(resolveDate('This Fri', d('2026-03-02'))).toBe('2026-03-06');
+    });
+
+    it('returns today if already Friday', () => {
+      // 2026-03-06 is a Friday
+      expect(resolveDate('This Fri', d('2026-03-06'))).toBe('2026-03-06');
+    });
+
+    it('returns next Friday when today is Saturday', () => {
+      // 2026-03-07 is a Saturday
+      expect(resolveDate('This Fri', d('2026-03-07'))).toBe('2026-03-13');
+    });
+
+    it('returns next Friday when today is Sunday', () => {
+      // 2026-03-08 is a Sunday
+      expect(resolveDate('This Fri', d('2026-03-08'))).toBe('2026-03-13');
+    });
+
+    it('returns coming Friday when today is Wednesday', () => {
+      // 2026-03-04 is a Wednesday
+      expect(resolveDate('This Fri', d('2026-03-04'))).toBe('2026-03-06');
+    });
+  });
+
+  describe('Next Mon', () => {
+    it('returns Monday of next week when today is Monday', () => {
+      // 2026-03-02 is Monday → next Monday is 2026-03-09
+      expect(resolveDate('Next Mon', d('2026-03-02'))).toBe('2026-03-09');
+    });
+
+    it('returns coming Monday when today is Sunday', () => {
+      // 2026-03-08 is Sunday → next day Monday is 2026-03-09
+      expect(resolveDate('Next Mon', d('2026-03-08'))).toBe('2026-03-09');
+    });
+
+    it('returns next Monday when today is Friday', () => {
+      // 2026-03-06 is Friday → next Monday is 2026-03-09
+      expect(resolveDate('Next Mon', d('2026-03-06'))).toBe('2026-03-09');
+    });
+
+    it('returns next Monday when today is Saturday', () => {
+      // 2026-03-07 is Saturday → next Monday is 2026-03-09
+      expect(resolveDate('Next Mon', d('2026-03-07'))).toBe('2026-03-09');
+    });
+
+    it('returns next Monday when today is Wednesday', () => {
+      // 2026-03-04 is Wednesday → next Monday is 2026-03-09
+      expect(resolveDate('Next Mon', d('2026-03-04'))).toBe('2026-03-09');
+    });
+  });
+
+  describe('Next Month', () => {
+    it('returns 1st of following month', () => {
+      expect(resolveDate('Next Month', d('2026-03-07'))).toBe('2026-04-01');
+    });
+
+    it('rolls over year boundary', () => {
+      expect(resolveDate('Next Month', d('2026-12-15'))).toBe('2027-01-01');
+    });
+
+    it('works on last day of month', () => {
+      expect(resolveDate('Next Month', d('2026-01-31'))).toBe('2026-02-01');
+    });
+  });
+});
+
+describe('matchShortcut — AC4: Active chip state', () => {
+  it('returns matching shortcut for "Today"', () => {
+    const ref = d('2026-03-07');
+    expect(matchShortcut('2026-03-07', ref)).toBe('Today');
+  });
+
+  it('returns matching shortcut for "This Fri"', () => {
+    // 2026-03-04 is Wednesday, This Fri = 2026-03-06
+    const ref = d('2026-03-04');
+    expect(matchShortcut('2026-03-06', ref)).toBe('This Fri');
+  });
+
+  it('returns null when no shortcut matches', () => {
+    const ref = d('2026-03-07');
+    expect(matchShortcut('2026-06-15', ref)).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(matchShortcut('')).toBeNull();
+  });
+});
+
+describe('DATE_SHORTCUTS', () => {
+  it('exports all four shortcuts in order', () => {
+    expect(DATE_SHORTCUTS).toEqual(['Today', 'This Fri', 'Next Mon', 'Next Month']);
+  });
+});

--- a/frontend/src/utils/date-shortcuts.ts
+++ b/frontend/src/utils/date-shortcuts.ts
@@ -1,0 +1,56 @@
+/** Quick date shortcut resolution logic for issue #82. */
+
+export type DateShortcut = 'Today' | 'This Fri' | 'Next Mon' | 'Next Month';
+
+export const DATE_SHORTCUTS: DateShortcut[] = ['Today', 'This Fri', 'Next Mon', 'Next Month'];
+
+/**
+ * Resolve a date shortcut to a YYYY-MM-DD string.
+ * @param shortcut - The shortcut label to resolve.
+ * @param ref - Reference date (defaults to today). Used for testing.
+ */
+export function resolveDate(shortcut: DateShortcut, ref: Date = new Date()): string {
+  const d = new Date(ref.getFullYear(), ref.getMonth(), ref.getDate());
+
+  switch (shortcut) {
+    case 'Today':
+      break;
+    case 'This Fri': {
+      const day = d.getDay(); // 0=Sun..6=Sat
+      const diff = day <= 5 ? 5 - day : 6; // if Sat (6), next Fri is 6 days away
+      d.setDate(d.getDate() + diff);
+      break;
+    }
+    case 'Next Mon': {
+      const day = d.getDay();
+      const diff = day === 0 ? 1 : 8 - day; // Sun=1 day, Mon=7, Tue=6, ..., Sat=2
+      d.setDate(d.getDate() + diff);
+      break;
+    }
+    case 'Next Month':
+      d.setDate(1); // set day first to avoid month overflow (e.g. Jan 31 → Mar 3)
+      d.setMonth(d.getMonth() + 1);
+      break;
+  }
+
+  return formatDate(d);
+}
+
+/**
+ * Check which shortcut (if any) matches a given date string.
+ * Returns the matching shortcut or null.
+ */
+export function matchShortcut(dateStr: string, ref: Date = new Date()): DateShortcut | null {
+  if (!dateStr) return null;
+  for (const s of DATE_SHORTCUTS) {
+    if (resolveDate(s, ref) === dateStr) return s;
+  }
+  return null;
+}
+
+function formatDate(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${dd}`;
+}


### PR DESCRIPTION
## Summary
Adds quick-select date shortcut chips (Today, This Fri, Next Mon, Next Month) below due date and scheduled date fields in both the create-item modal and card detail panel.

Closes #82

## Changes
- `frontend/src/utils/date-shortcuts.ts` — New date resolution utility with pure functions for resolving shortcut labels to YYYY-MM-DD strings and matching current dates to shortcuts
- `frontend/src/utils/date-shortcuts.test.ts` — 19 unit tests covering all resolution logic and edge cases (month overflow, year boundary, day-of-week variations)
- `frontend/src/components/shared/quick-date-chips.tsx` — New reusable QuickDateChips component with active state and clear-on-tap behavior
- `frontend/src/components/shared/quick-date-chips.test.tsx` — 8 component tests for rendering, click behavior, active state, and accessibility
- `frontend/src/components/forms/create-item-modal.tsx` — Integrated QuickDateChips below both date fields
- `frontend/src/components/forms/create-item-modal.test.tsx` — 5 new integration tests for chip → form data flow
- `frontend/src/components/board/card-detail.tsx` — Integrated QuickDateChips in date SaveFeedbackFields with save-on-click
- `frontend/src/global.css` — Quick date chip styles (reuses filter-chip visual pattern), 44px mobile touch targets

## Testing
- AC1 (chips on create modal): Tests verify chips render below both date fields and populate date inputs on click
- AC2 (date resolution): 19 unit tests cover Today, This Fri, Next Mon, Next Month including edge cases
- AC3 (chips on card detail): Integrated via SaveFeedbackField render prop with async save
- AC4 (active chip state): Component tests verify active styling, aria-pressed, and clear-on-tap
- AC5 (mobile layout): CSS uses 44px min-height at ≤768px breakpoint, flex-wrap for natural wrapping

## Rules Sync
- [x] Business rules in `frontend/src/state/rules.ts` — N/A (no rule changes)
- [x] Business rules in `apps-script/src/rules.js` — N/A (no rule changes)
- [x] Both files remain in sync