### PR TITLE
feat: add date fields (due date & scheduled date) to sub-tasks

### DIFF
--- a/frontend/src/components/board/card-detail.test.tsx
+++ b/frontend/src/components/board/card-detail.test.tsx
@@ -1281,12 +1281,16 @@ describe('CardDetail sub-task date fields (Issue #86)', () => {
       expect(badges[1].textContent).toContain('Mar 15');
     });
 
-    it('shows no date indicators for sub-tasks without dates', () => {
+    it('shows no date indicator badges for sub-tasks without dates', () => {
       mockChildren = [childNoDates];
       mockItems = [childNoDates];
       const { container } = renderCardDetail();
+      // No date badges (the compact "Due: Mar 8" display elements)
       const badges = container.querySelectorAll('.subtask-date-badge');
       expect(badges.length).toBe(0);
+      // Add-affordance buttons are present (hidden via CSS, but in DOM)
+      const addBtns = container.querySelectorAll('.subtask-date-add');
+      expect(addBtns.length).toBe(2);
     });
 
     it('shows overdue styling on past-due sub-task due dates', () => {
@@ -1363,6 +1367,52 @@ describe('CardDetail sub-task date fields (Issue #86)', () => {
       const label = dueBadge.getAttribute('aria-label') || '';
       expect(label).toContain('Due date:');
       expect(label).toContain('Click to edit');
+    });
+
+    it('clicking "Due +" affordance opens due date editor for dateless sub-task', () => {
+      mockChildren = [childNoDates];
+      mockItems = [childNoDates];
+      const { container } = renderCardDetail();
+      const dueAddBtn = container.querySelector('.subtask-date-add[aria-label^="Add due date"]') as HTMLElement;
+      expect(dueAddBtn).not.toBeNull();
+      fireEvent.click(dueAddBtn);
+      const dateInput = container.querySelector('.subtask-date-input') as HTMLInputElement;
+      expect(dateInput).not.toBeNull();
+      expect(dateInput.getAttribute('aria-label')).toContain('Due date');
+    });
+
+    it('clicking "Sched +" affordance opens scheduled date editor for dateless sub-task', () => {
+      mockChildren = [childNoDates];
+      mockItems = [childNoDates];
+      const { container } = renderCardDetail();
+      const schedAddBtn = container.querySelector('.subtask-date-add[aria-label^="Add scheduled date"]') as HTMLElement;
+      expect(schedAddBtn).not.toBeNull();
+      fireEvent.click(schedAddBtn);
+      const dateInput = container.querySelector('.subtask-date-input') as HTMLInputElement;
+      expect(dateInput).not.toBeNull();
+      expect(dateInput.getAttribute('aria-label')).toContain('Scheduled date');
+    });
+
+    it('shows "Sched +" affordance when sub-task has due date but no scheduled date', () => {
+      const childDueOnly = { ...childWithDates, scheduled_date: '' };
+      mockChildren = [childDueOnly];
+      mockItems = [childDueOnly];
+      const { container } = renderCardDetail();
+      // Due badge (not affordance) for existing due date
+      expect(container.querySelector('.subtask-date-badge')).not.toBeNull();
+      // Sched+ affordance for missing scheduled date
+      const schedAdd = container.querySelector('.subtask-date-add[aria-label^="Add scheduled date"]');
+      expect(schedAdd).not.toBeNull();
+    });
+
+    it('shows no add-affordance buttons when both dates are set', () => {
+      const { container } = renderCardDetail();
+      // childWithDates has both dates set — no affordance buttons
+      const addBtns = container.querySelectorAll('.subtask-date-add');
+      // Only childNoDates (second child) would have affordances, childWithDates has none
+      // childWithDates → 0 affordances; childNoDates → 2 affordances
+      // With both children in default beforeEach: 2 affordances total (from childNoDates only)
+      expect(addBtns.length).toBe(2);
     });
   });
 

--- a/frontend/src/components/board/card-detail.tsx
+++ b/frontend/src/components/board/card-detail.tsx
@@ -756,12 +756,11 @@ function SubtaskDates({ child, onSave }: {
     );
   }
 
-  // No dates and not editing — show nothing (AC1: "sub-tasks with no dates set show no date indicators")
-  if (!hasDue && !hasSched) return null;
-
+  // Always render the container — date badges for set dates, add-affordance buttons for unset ones.
+  // Add-affordances are opacity:0 by default, revealed on subtask-item hover/focus (AC2).
   return (
     <span class="subtask-dates">
-      {hasDue && (
+      {hasDue ? (
         <button
           class={`subtask-date-badge ${dueOverdue ? 'subtask-date-overdue' : ''}`}
           aria-label={`Due date: ${formatCompactDate(child.due_date)}${dueOverdue ? ', overdue' : ''}. Click to edit.`}
@@ -769,14 +768,30 @@ function SubtaskDates({ child, onSave }: {
         >
           Due: {formatCompactDate(child.due_date)}
         </button>
+      ) : (
+        <button
+          class="subtask-date-add"
+          aria-label={`Add due date for ${child.title}`}
+          onClick={(e) => { e.stopPropagation(); setEditingField('due_date'); }}
+        >
+          Due +
+        </button>
       )}
-      {hasSched && (
+      {hasSched ? (
         <button
           class="subtask-date-badge"
           aria-label={`Scheduled date: ${formatCompactDate(child.scheduled_date)}. Click to edit.`}
           onClick={(e) => { e.stopPropagation(); setEditingField('scheduled_date'); }}
         >
           Sched: {formatCompactDate(child.scheduled_date)}
+        </button>
+      ) : (
+        <button
+          class="subtask-date-add"
+          aria-label={`Add scheduled date for ${child.title}`}
+          onClick={(e) => { e.stopPropagation(); setEditingField('scheduled_date'); }}
+        >
+          Sched +
         </button>
       )}
     </span>

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -1163,6 +1163,36 @@ body {
   border-color: var(--color-overdue);
 }
 
+/* #86 AC2: "Set date" affordance for dateless sub-tasks — hidden until hover/focus */
+.subtask-date-add {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 5px;
+  font-size: 11px;
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  font-family: inherit;
+  white-space: nowrap;
+  line-height: 1.4;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.subtask-item:hover .subtask-date-add,
+.subtask-item:focus-within .subtask-date-add {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.subtask-date-add:hover {
+  color: var(--color-primary);
+  border-color: var(--color-primary);
+  border-style: solid;
+}
+
 .subtask-date-input {
   font-size: 12px;
   padding: 2px 4px;
@@ -2140,6 +2170,15 @@ body {
   }
 
   .subtask-date-badge {
+    min-height: 44px;
+    padding: 4px 10px;
+    font-size: 13px;
+  }
+
+  /* #86 AC5: Add-affordance always visible on mobile, 44px touch target */
+  .subtask-date-add {
+    opacity: 1;
+    pointer-events: auto;
     min-height: 44px;
     padding: 4px 10px;
     font-size: 13px;


### PR DESCRIPTION
## Summary
Add due date and scheduled date display and inline editing to sub-task rows in the card detail panel. Also adds optional date inputs to the sub-task creation row.

Closes #86

## Changes
- **`frontend/src/components/board/card-detail.tsx`**
  - New `SubtaskDates` component: renders compact date badges (Due: Mar 8, Sched: Mar 13) with overdue styling; click to edit inline via date input
  - Added `handleSubtaskDateSave()` for persisting sub-task date changes via `updateItem()`
  - Creation row now includes two optional date inputs (due date, scheduled date) that pass through to `createItem()`
  - Helper functions: `parseLocalDate()`, `formatCompactDate()`, `isOverdue()` (same logic as parent card)
  
- **`frontend/src/global.css`**
  - New `.subtask-dates`, `.subtask-date-badge`, `.subtask-date-overdue`, `.subtask-date-input` styles
  - New `.subtask-add-date` styles for creation row date inputs
  - Mobile breakpoint (≤768px): dates wrap to second line, 44px touch targets, creation row wraps

- **`frontend/src/components/board/card-detail.test.tsx`**
  - 15 new tests covering all 5 acceptance criteria:
    - AC1: compact date display, no-date case, overdue styling, Done suppression
    - AC2: click-to-edit, onChange save, blur close, Escape close, accessible labels
    - AC3: creation row date inputs present, default empty, dates in createItem, no dates omitted
    - AC4: no cross-validation with parent dates

## Testing
- AC1 → 4 tests (date display, no dates, overdue, Done)
- AC2 → 5 tests (inline editing, save, blur, Escape, a11y)
- AC3 → 4 tests (creation inputs, defaults, with dates, without dates)
- AC4 → 1 test (no cross-validation)
- AC5 → CSS-only (verified via mobile breakpoint rules); touch targets meet 44px min-height

## Rules Sync
- [x] No business rules modified — purely UI feature
- [x] Data model already supports dates on sub-tasks