### PR TITLE
chore: add --color-primary-light token and unify accent tints

### DIFF
--- a/frontend/src/design-tokens.test.ts
+++ b/frontend/src/design-tokens.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+
+// @ts-ignore -- Node builtins available at test runtime
+import { readFileSync } from 'fs';
+// @ts-ignore
+import { resolve } from 'path';
+
+// @ts-ignore -- __dirname available in vitest CJS context
+const cssPath = resolve(__dirname, 'global.css');
+const css = readFileSync(cssPath, 'utf-8');
+
+/**
+ * Extract the content of the :root block from CSS source.
+ */
+function extractRootBlock(source: string): string {
+  const re = /:root\s*\{/g;
+  const match = re.exec(source);
+  if (!match) return '';
+
+  let depth = 1;
+  let i = match.index + match[0].length;
+  const start = i;
+  while (i < source.length && depth > 0) {
+    if (source[i] === '{') depth++;
+    if (source[i] === '}') depth--;
+    i++;
+  }
+  return source.slice(start, i - 1);
+}
+
+const rootBlock = extractRootBlock(css);
+
+describe('Design token: --color-primary-light (Issue #104)', () => {
+  // AC1: Token defined in :root
+  describe('AC1: Token defined in :root', () => {
+    it('--color-primary-light is defined in :root', () => {
+      expect(rootBlock).toContain('--color-primary-light');
+    });
+
+    it('uses color-mix with 8% primary', () => {
+      expect(rootBlock).toMatch(
+        /--color-primary-light:\s*color-mix\(in srgb,\s*var\(--color-primary\)\s+8%,\s*transparent\)/
+      );
+    });
+
+    it('no dark-mode override for --color-primary-light', () => {
+      const darkThemeMatch = css.match(/\[data-theme=["']dark["']\]\s*\{([^}]*)\}/);
+      if (darkThemeMatch) {
+        expect(darkThemeMatch[1]).not.toContain('--color-primary-light');
+      }
+    });
+  });
+
+  // AC2: Ad-hoc primary tints unified under the token
+  describe('AC2: Ad-hoc tints replaced with var(--color-primary-light)', () => {
+    it('.share-btn:hover uses var(--color-primary-light)', () => {
+      const match = css.match(/\.share-btn:hover\s*\{[^}]*\}/);
+      expect(match).not.toBeNull();
+      expect(match![0]).toContain('var(--color-primary-light)');
+      expect(match![0]).not.toContain('rgba(var(--color-primary-rgb)');
+    });
+
+    it('.share-member-highlight uses var(--color-primary-light)', () => {
+      const match = css.match(/\.share-member-highlight\s*\{[^}]*\}/);
+      expect(match).not.toBeNull();
+      expect(match![0]).toContain('var(--color-primary-light)');
+      expect(match![0]).not.toContain('rgba(var(--color-primary-rgb)');
+    });
+
+    it('.quick-date-chip:hover uses var(--color-primary-light)', () => {
+      const match = css.match(/\.quick-date-chip:hover\s*\{[^}]*\}/);
+      expect(match).not.toBeNull();
+      expect(match![0]).toContain('var(--color-primary-light)');
+      expect(match![0]).not.toContain('color-mix(in srgb, var(--color-primary) 8%');
+    });
+
+    it('.btn-icon-danger:hover no longer has transparent primary-rgb fallback', () => {
+      const match = css.match(/\.btn-icon-danger:hover\s*\{[^}]*\}/);
+      expect(match).not.toBeNull();
+      expect(match![0]).not.toContain('rgba(var(--color-primary-rgb)');
+    });
+
+    it('@keyframes share-fade retains 15% primary-rgb value', () => {
+      const match = css.match(/@keyframes share-fade\s*\{[^}]*from\s*\{[^}]*\}[^}]*\}/);
+      expect(match).not.toBeNull();
+      expect(match![0]).toContain('rgba(var(--color-primary-rgb), 0.15)');
+    });
+  });
+});

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -9,6 +9,7 @@
   --color-primary-hover: #1565c0;
   /* RGB components for alpha-blended highlights */
   --color-primary-rgb: 25, 118, 210;
+  --color-primary-light: color-mix(in srgb, var(--color-primary) 8%, transparent);
 
   /* Text */
   --color-text: #1f1f1f;
@@ -793,7 +794,7 @@ body {
 
 .share-btn:hover {
   color: var(--color-primary);
-  background: rgba(var(--color-primary-rgb), 0.08);
+  background: var(--color-primary-light);
 }
 
 /* === Share Modal === */
@@ -863,7 +864,7 @@ body {
 }
 
 .share-member-highlight {
-  background: rgba(var(--color-primary-rgb), 0.08);
+  background: var(--color-primary-light);
   animation: share-fade 2s ease-out forwards;
 }
 
@@ -2104,7 +2105,6 @@ body {
 }
 
 .btn-icon-danger:hover {
-  background: rgba(var(--color-primary-rgb), 0);   /* transparent — tinted below */
   background: color-mix(in srgb, var(--color-danger) 10%, transparent);
   color: var(--color-danger);
 }
@@ -2213,7 +2213,7 @@ body {
 .quick-date-chip:hover {
   border-color: var(--color-primary);
   color: var(--color-primary);
-  background: color-mix(in srgb, var(--color-primary) 8%, transparent);
+  background: var(--color-primary-light);
 }
 
 .quick-date-chip:focus-visible {


### PR DESCRIPTION
## Summary
Add a `--color-primary-light` CSS custom property token and replace all ad-hoc primary-tint expressions with the new token.

Closes #104

## Changes
- **`frontend/src/global.css`**: Added `--color-primary-light: color-mix(in srgb, var(--color-primary) 8%, transparent)` in `:root`. Replaced `rgba(var(--color-primary-rgb), 0.08)` in `.share-btn:hover` and `.share-member-highlight` with `var(--color-primary-light)`. Replaced inline `color-mix(...)` in `.quick-date-chip:hover` with the token. Removed dead-code transparent fallback in `.btn-icon-danger:hover`. `@keyframes share-fade` intentionally retains its 15% value.
- **`frontend/src/design-tokens.test.ts`**: New test file with 8 tests covering all 4 acceptance criteria — token definition, tint replacement, dead-code removal, and animation exclusion.

## Testing
- AC1 (token in :root): Tests verify `--color-primary-light` exists in `:root` with correct `color-mix` value, and no dark-mode override
- AC2 (tints unified): Tests verify `.share-btn:hover`, `.share-member-highlight`, `.quick-date-chip:hover` use `var(--color-primary-light)`, dead-code removed from `.btn-icon-danger:hover`, and `@keyframes share-fade` retains 0.15
- AC3/AC4 (visual): Require demo-mode visual verification (QA stage)

## Rules Sync
- [x] CSS-only change — no business rules affected