### PR TITLE
chore: add Hive logo to favicon, header, and login (#30)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Hive — Family Board</title>
-  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🐝</text></svg>" />
+  <link rel="icon" href="/hive/logo.svg" />
   <!-- AC4: Apply data-theme before first paint to prevent flash of wrong theme -->
   <script>
     (function() {

--- a/frontend/public/logo.svg
+++ b/frontend/public/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+  <polygon points="12 2 21 7 21 17 12 22 3 17 3 7" fill="#1976d2"/>
+  <path d="M6.5 12.8l3.4 3.4L17.5 9.2" fill="none" stroke="white" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/auth/login-screen.test.tsx
+++ b/frontend/src/auth/login-screen.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/preact';
+import { LoginScreen } from './login-screen';
+
+vi.mock('./auth-context', () => ({
+  useAuth: () => ({ login: vi.fn() }),
+}));
+
+vi.mock('../components/shared/hive-logo', () => ({
+  HiveLogo: (props: any) => <svg data-testid="hive-logo" width={props.size} class={props.class} />,
+}));
+
+describe('LoginScreen logo (Issue #30 AC4)', () => {
+  it('renders HiveLogo above the h1', () => {
+    const { container } = render(<LoginScreen />);
+    const card = container.querySelector('.login-card');
+    expect(card).not.toBeNull();
+    const logo = card!.querySelector('[data-testid="hive-logo"]');
+    expect(logo).not.toBeNull();
+
+    // Logo should come before h1
+    const children = Array.from(card!.children);
+    const logoIdx = children.findIndex(c => c.getAttribute('data-testid') === 'hive-logo');
+    const h1Idx = children.findIndex(c => c.tagName === 'H1');
+    expect(logoIdx).toBeLessThan(h1Idx);
+  });
+
+  it('renders logo at size 56', () => {
+    const { container } = render(<LoginScreen />);
+    const logo = container.querySelector('[data-testid="hive-logo"]');
+    expect(logo!.getAttribute('width')).toBe('56');
+  });
+
+  it('logo has the login-logo class', () => {
+    const { container } = render(<LoginScreen />);
+    const logo = container.querySelector('[data-testid="hive-logo"]');
+    expect(logo!.classList.contains('login-logo')).toBe(true);
+  });
+});

--- a/frontend/src/auth/login-screen.tsx
+++ b/frontend/src/auth/login-screen.tsx
@@ -1,4 +1,5 @@
 import { useAuth } from './auth-context';
+import { HiveLogo } from '../components/shared/hive-logo';
 
 export function LoginScreen() {
   const { login } = useAuth();
@@ -6,6 +7,7 @@ export function LoginScreen() {
   return (
     <div class="login-screen">
       <div class="login-card">
+        <HiveLogo size={56} class="login-logo" />
         <h1>Hive</h1>
         <p>Family Kanban Board</p>
         <button class="login-btn" onClick={login}>

--- a/frontend/src/components/board/kanban-board.test.tsx
+++ b/frontend/src/components/board/kanban-board.test.tsx
@@ -131,6 +131,9 @@ vi.mock('../archive/archive-dialog', () => ({
 vi.mock('./theme-toggle', () => ({
   ThemeToggle: () => <div data-testid="theme-toggle" />,
 }));
+vi.mock('../shared/hive-logo', () => ({
+  HiveLogo: (props: any) => <svg data-testid="hive-logo" class={props.class} />,
+}));
 
 const mockAuth: AuthState = {
   token: 'test-token',
@@ -415,5 +418,33 @@ describe('KanbanBoard keyboard shortcuts (Issue #91)', () => {
 
       expect(queryByTestId('shortcuts-help')).not.toBeNull();
     });
+  });
+});
+
+describe('KanbanBoard logo in header (Issue #30 AC3)', () => {
+  it('renders HiveLogo in the board-header-left', () => {
+    mockState.items = [];
+    const { container } = renderBoard();
+    const headerLeft = container.querySelector('.board-header-left');
+    expect(headerLeft).not.toBeNull();
+    const logo = headerLeft!.querySelector('[data-testid="hive-logo"]');
+    expect(logo).not.toBeNull();
+  });
+
+  it('logo appears before the h1 heading', () => {
+    mockState.items = [];
+    const { container } = renderBoard();
+    const headerLeft = container.querySelector('.board-header-left');
+    const children = Array.from(headerLeft!.children);
+    const logoIdx = children.findIndex(c => c.getAttribute('data-testid') === 'hive-logo');
+    const h1Idx = children.findIndex(c => c.tagName === 'H1');
+    expect(logoIdx).toBeLessThan(h1Idx);
+  });
+
+  it('logo has the board-header-logo class', () => {
+    mockState.items = [];
+    const { container } = renderBoard();
+    const logo = container.querySelector('[data-testid="hive-logo"]');
+    expect(logo!.classList.contains('board-header-logo')).toBe(true);
   });
 });

--- a/frontend/src/components/board/kanban-board.tsx
+++ b/frontend/src/components/board/kanban-board.tsx
@@ -16,6 +16,7 @@ import { ProfileDialog } from '../profile/profile-dialog';
 import { ArchiveDialog } from '../archive/archive-dialog';
 import { FilterBar } from '../filters/filter-bar';
 import { ThemeToggle } from './theme-toggle';
+import { HiveLogo } from '../shared/hive-logo';
 import type { ItemStatus, ItemWithRow } from '../../api/types';
 
 export function KanbanBoard() {
@@ -210,6 +211,7 @@ export function KanbanBoard() {
     <div class="board-layout">
       <header class="board-header">
         <div class="board-header-left">
+          <HiveLogo class="board-header-logo" />
           <h1>Hive</h1>
         </div>
         <div class="board-header-right">

--- a/frontend/src/components/shared/hive-logo.test.tsx
+++ b/frontend/src/components/shared/hive-logo.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/preact';
+import { HiveLogo } from './hive-logo';
+
+describe('HiveLogo (Issue #30 AC1)', () => {
+  it('renders an SVG element with aria-hidden="true"', () => {
+    const { container } = render(<HiveLogo />);
+    const svg = container.querySelector('svg');
+    expect(svg).not.toBeNull();
+    expect(svg!.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('defaults to size 24', () => {
+    const { container } = render(<HiveLogo />);
+    const svg = container.querySelector('svg');
+    expect(svg!.getAttribute('width')).toBe('24');
+    expect(svg!.getAttribute('height')).toBe('24');
+  });
+
+  it('accepts a custom size prop', () => {
+    const { container } = render(<HiveLogo size={48} />);
+    const svg = container.querySelector('svg');
+    expect(svg!.getAttribute('width')).toBe('48');
+    expect(svg!.getAttribute('height')).toBe('48');
+  });
+
+  it('forwards the class prop to the root SVG', () => {
+    const { container } = render(<HiveLogo class="my-class" />);
+    const svg = container.querySelector('svg');
+    expect(svg!.classList.contains('my-class')).toBe(true);
+  });
+
+  it('uses var(--color-primary) as the fill colour', () => {
+    const { container } = render(<HiveLogo />);
+    const polygon = container.querySelector('polygon');
+    expect(polygon).not.toBeNull();
+    expect(polygon!.getAttribute('fill')).toBe('var(--color-primary)');
+  });
+
+  it('contains the hexagon and checkmark shapes', () => {
+    const { container } = render(<HiveLogo />);
+    const polygon = container.querySelector('polygon');
+    const path = container.querySelector('path');
+    expect(polygon).not.toBeNull();
+    expect(path).not.toBeNull();
+    expect(path!.getAttribute('stroke')).toBe('white');
+  });
+});

--- a/frontend/src/components/shared/hive-logo.tsx
+++ b/frontend/src/components/shared/hive-logo.tsx
@@ -1,0 +1,27 @@
+interface HiveLogoProps {
+  size?: number;
+  class?: string;
+}
+
+export function HiveLogo({ size = 24, class: className }: HiveLogoProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      width={size}
+      height={size}
+      class={className}
+    >
+      <polygon points="12 2 21 7 21 17 12 22 3 17 3 7" fill="var(--color-primary)" />
+      <path
+        d="M7 12.5l3.2 3.2L17 9.5"
+        fill="none"
+        stroke="white"
+        stroke-width="2.6"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+  );
+}

--- a/frontend/src/favicon.test.ts
+++ b/frontend/src/favicon.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+
+// @ts-ignore -- Node builtins available at test runtime
+import { readFileSync } from 'fs';
+// @ts-ignore
+import { resolve } from 'path';
+
+// @ts-ignore -- __dirname available in vitest CJS context
+const indexPath = resolve(__dirname, '../index.html');
+// @ts-ignore
+const logoPath = resolve(__dirname, '../public/logo.svg');
+
+describe('Favicon (Issue #30 AC2)', () => {
+  it('index.html references /hive/logo.svg as the favicon', () => {
+    const html = readFileSync(indexPath, 'utf-8');
+    expect(html).toContain('rel="icon"');
+    expect(html).toContain('href="/hive/logo.svg"');
+  });
+
+  it('does not contain the old bee emoji favicon', () => {
+    const html = readFileSync(indexPath, 'utf-8');
+    expect(html).not.toContain('🐝');
+  });
+
+  it('logo.svg exists in the public directory', () => {
+    const svg = readFileSync(logoPath, 'utf-8');
+    expect(svg).toContain('<svg');
+    expect(svg).toContain('#1976d2');
+  });
+});

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -177,6 +177,11 @@ body {
   text-align: center;
 }
 
+.login-logo {
+  display: block;
+  margin: 0 auto 14px;
+}
+
 .login-card h1 {
   font-size: 36px;
   margin-bottom: 8px;
@@ -302,6 +307,18 @@ body {
   padding: 0 20px;
   background: var(--color-surface);
   border-bottom: 1px solid var(--color-border);
+  flex-shrink: 0;
+}
+
+.board-header-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.board-header-logo {
+  width: 26px;
+  height: 26px;
   flex-shrink: 0;
 }
 
@@ -2499,5 +2516,13 @@ body {
 
   .profile-dialog form input[type="text"] {
     min-height: 44px;
+  }
+}
+
+/* === Board header logo responsive (#30) === */
+@media (max-width: 479px) {
+  .board-header-logo {
+    width: 20px;
+    height: 20px;
   }
 }


### PR DESCRIPTION
## Summary
Add the hexagon-with-checkmark SVG logo to the Hive app — favicon, board header, and login screen.

Closes #30

## Changes
- `frontend/public/logo.svg` — copied from `hive-favicon.svg` with hardcoded `#1976d2` for favicon use
- `frontend/src/components/shared/hive-logo.tsx` — new `<HiveLogo>` component inlining SVG markup with `size` (default 24) and `class` props, using `var(--color-primary)` fill
- `frontend/index.html` — swapped bee emoji favicon for `/hive/logo.svg`
- `frontend/src/components/board/kanban-board.tsx` — added `<HiveLogo>` to `.board-header-left` before the `<h1>`
- `frontend/src/auth/login-screen.tsx` — added `<HiveLogo size={56}>` above the `<h1>` in the login card
- `frontend/src/global.css` — added `.board-header-left` flex layout, `.board-header-logo` sizing (26px desktop, 20px at <480px), `.login-logo` spacing (14px margin-bottom)

## Testing
- AC1 (HiveLogo component): 6 tests in `hive-logo.test.tsx` — aria-hidden, default size, custom size, class forwarding, fill colour, SVG shapes
- AC2 (Favicon): 3 tests in `favicon.test.ts` — index.html references, no bee emoji, logo.svg exists with hardcoded colour
- AC3 (Board header): 3 tests in `kanban-board.test.tsx` — logo in header-left, before h1, has correct class
- AC4 (Login screen): 3 tests in `login-screen.test.tsx` — logo above h1, size 56, login-logo class

## Rules Sync
- [ ] Business rules in `frontend/src/state/rules.ts` updated (if applicable) — N/A
- [ ] Business rules in `apps-script/src/rules.js` updated (if applicable) — N/A
- [x] Both files remain in sync