### PR TITLE
fix: dark mode subtask edit input unreadable text (#133)

### DIFF
--- a/frontend/src/components/board/dark-mode-subtask-inputs.test.ts
+++ b/frontend/src/components/board/dark-mode-subtask-inputs.test.ts
@@ -69,6 +69,22 @@ describe('Dark mode subtask input backgrounds (Issue #111)', () => {
     });
   });
 
+  // AC-133-3: .subtask-title-input has explicit color: var(--color-text)
+  describe('AC3 (#133): .subtask-title-input has explicit color token', () => {
+    it('.subtask-title-input rule sets color: var(--color-text)', () => {
+      const block = extractRuleBlock(css, '.subtask-title-input');
+      expect(block).toContain('color: var(--color-text)');
+    });
+  });
+
+  // AC-133-5: .subtask-title-input:focus has box-shadow: var(--focus-ring)
+  describe('AC5 (#133): .subtask-title-input:focus has visible focus ring', () => {
+    it('.subtask-title-input:focus rule sets box-shadow: var(--focus-ring)', () => {
+      const block = extractRuleBlock(css, '.subtask-title-input:focus');
+      expect(block).toContain('box-shadow: var(--focus-ring)');
+    });
+  });
+
   // AC4: Dark mode contrast — --color-text on --color-surface meets WCAG AA
   describe('AC4: Dark mode tokens meet WCAG AA contrast', () => {
     it('dark theme defines --color-surface: #1e1e1e', () => {

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -1315,6 +1315,11 @@ body {
   border-radius: var(--radius-sm);
   outline: none;
   background: var(--color-surface);
+  color: var(--color-text);
+}
+
+.subtask-title-input:focus {
+  box-shadow: var(--focus-ring);
 }
 
 .subtask-done span {


### PR DESCRIPTION
## Summary
Fix unreadable subtask edit input text in dark mode by adding an explicit color token and focus ring.

Closes #133

## Changes
- **frontend/src/global.css** — Added `color: var(--color-text)` to `.subtask-title-input` rule so text inherits the correct theme color. Added `.subtask-title-input:focus { box-shadow: var(--focus-ring); }` for WCAG 2.4.7 focus indicator consistency with `.subtask-add-input:focus` and `.subtask-date-input:focus`.
- **frontend/src/components/board/dark-mode-subtask-inputs.test.ts** — Added 2 test cases: AC3 verifies `.subtask-title-input` has `color: var(--color-text)`, AC5 verifies `.subtask-title-input:focus` has `box-shadow: var(--focus-ring)`.

## Testing
- AC1 (dark mode readable): Verified via existing dark-mode contrast ratio test + new color token test
- AC2 (light mode readable): `--color-text` resolves to dark color in light mode (existing token test)
- AC3 (explicit color token): New test — `.subtask-title-input` rule contains `color: var(--color-text)`
- AC4 (non-regression): No changes to `.subtask-add-input` — existing tests still pass
- AC5 (focus ring): New test — `.subtask-title-input:focus` rule contains `box-shadow: var(--focus-ring)`

## Rules Sync
- [x] Not applicable — visual styling only, no business rule changes