### PR TITLE
fix: list mode missing vertical scroll bar on desktop (#137)

### DIFF
--- a/frontend/src/components/board/kanban-board.test.tsx
+++ b/frontend/src/components/board/kanban-board.test.tsx
@@ -14,6 +14,7 @@ const mockState = {
   showArchiveDialog: false,
   selectedItem: null as any,
   accessibleBoards: [] as any[],
+  viewMode: 'board' as string,
 };
 
 const mockSwitchBoard = vi.fn();
@@ -28,6 +29,7 @@ afterEach(() => {
   mockState.showArchiveDialog = false;
   mockState.selectedItem = null;
   mockState.accessibleBoards = [];
+  mockState.viewMode = 'board';
   mockSwitchBoard.mockClear();
   mockMoveItem.mockClear();
 });
@@ -63,8 +65,8 @@ vi.mock('../../state/board-store', () => ({
   filterLabel: { value: null },
   loading: { value: false },
   getChildCount: () => ({ done: 0, total: 0 }),
-  viewMode: { value: 'board' },
-  setViewMode: () => {},
+  viewMode: { get value() { return mockState.viewMode; } },
+  setViewMode: (v: string) => { mockState.viewMode = v; },
   allDoneItems: { value: [] },
   hasArchivedItems: { value: false },
   showArchiveDialog: {
@@ -115,7 +117,7 @@ vi.mock('../header/control-bar', () => ({
 
 // Mock other sub-components
 vi.mock('./list-view', () => ({
-  ListView: () => <div data-testid="list-view" />,
+  ListView: () => <div class="list-view" data-testid="list-view" />,
 }));
 vi.mock('./card-detail', () => ({
   CardDetail: () => <div data-testid="card-detail" />,
@@ -444,5 +446,37 @@ describe('KanbanBoard logo in header (Issue #30 AC3)', () => {
     const { container } = renderBoard();
     const logo = container.querySelector('[data-testid="hive-logo"]');
     expect(logo!.classList.contains('board-header-logo')).toBe(true);
+  });
+});
+
+describe('List mode scroll — DOM structure (Issue #137)', () => {
+  const sampleItem = {
+    id: '1', title: 'Task A', description: '', status: 'To Do',
+    owner: '', due_date: '', labels: '', parent_id: '',
+    created_at: '', updated_at: '', completed_at: '',
+    sort_order: 1, created_by: '', board_id: '', sheetRow: 2,
+  };
+
+  // AC1 / AC2: board-main must contain .list-view when in list mode so the
+  // CSS selector `.board-main:has(.list-view)` can set overflow-y: auto.
+  it('renders .list-view inside .board-main when viewMode is list', () => {
+    mockState.items = [sampleItem];
+    mockState.viewMode = 'list';
+    const { container } = renderBoard();
+    const boardMain = container.querySelector('.board-main');
+    expect(boardMain).not.toBeNull();
+    const listView = boardMain!.querySelector('.list-view');
+    expect(listView).not.toBeNull();
+  });
+
+  // AC3: kanban mode must NOT have .list-view inside .board-main
+  it('does not render .list-view inside .board-main when viewMode is board', () => {
+    mockState.items = [sampleItem];
+    mockState.viewMode = 'board';
+    const { container } = renderBoard();
+    const boardMain = container.querySelector('.board-main');
+    expect(boardMain).not.toBeNull();
+    const listView = boardMain!.querySelector('.list-view');
+    expect(listView).toBeNull();
   });
 });

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -624,6 +624,12 @@ body {
   padding: 16px 20px;
 }
 
+/* In list mode, board-main scrolls vertically instead of horizontally */
+.board-main:has(.list-view) {
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
 /* === Columns === */
 .board-columns {
   display: flex;
@@ -2598,12 +2604,6 @@ body {
 
   .filter-group {
     flex-wrap: wrap;
-  }
-
-  /* In list mode, board-main scrolls vertically instead of horizontally */
-  .board-main:has(.list-view) {
-    overflow-x: hidden;
-    overflow-y: auto;
   }
 
   /* Board switcher: touch-friendly on mobile */


### PR DESCRIPTION
## Summary
List mode had no vertical scroll bar on desktop/tablet viewports because the `.board-main:has(.list-view)` CSS override was scoped inside the `@media (max-width: 768px)` block, so it never fired on wider screens.

Closes #137

## Changes
- `frontend/src/global.css` — moved `.board-main:has(.list-view) { overflow-x: hidden; overflow-y: auto; }` from the mobile media query to the base styles section (near the `.board-main` block), so it applies at all viewport widths; removed the now-duplicate rule from the media query
- `frontend/src/components/board/kanban-board.test.tsx` — updated `ListView` mock to include `class="list-view"` (matching the real component); made `viewMode` in mock state dynamic via `mockState.viewMode`; added two tests verifying the DOM structure that the CSS selector targets

## Testing
- AC1/AC2: test verifies `.list-view` is rendered inside `.board-main` when `viewMode === 'list'`
- AC3: test verifies no `.list-view` inside `.board-main` when `viewMode === 'board'`
- AC4: covered by AC1/AC2 — `overflow: auto` only shows scroll bar when content overflows

## Rules Sync
- [ ] Business rules in `frontend/src/state/rules.ts` updated (if applicable) — N/A (pure CSS fix)
- [ ] Business rules in `apps-script/src/rules.js` updated (if applicable) — N/A
- [x] Both files remain in sync