### PR TITLE
feat: improve drag-and-drop UX for date-sorted columns

### DIFF
--- a/frontend/src/components/board/column.test.tsx
+++ b/frontend/src/components/board/column.test.tsx
@@ -33,6 +33,7 @@ vi.mock('../../state/board-store', () => ({
   labels: { value: [] },
   getChildCount: () => ({ done: 0, total: 0 }),
   showToast: (...args: unknown[]) => mockShowToast(...args),
+  columnAnnouncement: { value: null },
 }));
 
 // Controllable mock for the card module so tests can set currentDragStatus
@@ -94,14 +95,14 @@ describe('Column drop indicator (Issue #115 AC2)', () => {
   });
 
   it('shows drop indicator when dragging from a different column (cross-column drag) — AC1', async () => {
-    // Simulate a card from "In Progress" being dragged over the "To Do" column
+    // Simulate a card from "In Progress" being dragged over the "To Do" column (custom sort)
     cardMock.currentDragStatus = 'In Progress';
 
     const items = [
       makeItem({ id: '1', title: 'Task 1', status: 'To Do' }),
     ];
     const { container } = render(
-      <Column status="To Do" items={items} onDrop={vi.fn()} onReorder={vi.fn()} />
+      <Column status="To Do" items={items} onDrop={vi.fn()} onReorder={vi.fn()} sortMode="custom" />
     );
     const card = container.querySelector('.card') as HTMLElement;
 
@@ -156,7 +157,7 @@ describe('Cross-column drop with position (Issue #128 AC2)', () => {
     cardMock.currentDragStatus = null;
   });
 
-  it('calls onDrop with targetIndex when cross-column dropping above a card', async () => {
+  it('calls onDrop with targetIndex when cross-column dropping above a card (custom sort)', async () => {
     cardMock.currentDragStatus = 'In Progress';
     const onDrop = vi.fn();
     const items = [
@@ -164,7 +165,7 @@ describe('Cross-column drop with position (Issue #128 AC2)', () => {
       makeItem({ id: '2', title: 'Task 2', status: 'To Do', sort_order: 2 }),
     ];
     const { container } = render(
-      <Column status="To Do" items={items} onDrop={onDrop} onReorder={vi.fn()} />
+      <Column status="To Do" items={items} onDrop={onDrop} onReorder={vi.fn()} sortMode="custom" />
     );
     const firstCard = container.querySelectorAll('[data-item-id]')[0] as HTMLElement;
 
@@ -194,14 +195,14 @@ describe('Cross-column drop with position (Issue #128 AC2)', () => {
     rectSpy.mockRestore();
   });
 
-  it('calls onDrop with targetIndex below card when cursor is in lower half', async () => {
+  it('calls onDrop with targetIndex below card when cursor is in lower half (custom sort)', async () => {
     cardMock.currentDragStatus = 'In Progress';
     const onDrop = vi.fn();
     const items = [
       makeItem({ id: '1', title: 'Task 1', status: 'To Do', sort_order: 1 }),
     ];
     const { container } = render(
-      <Column status="To Do" items={items} onDrop={onDrop} onReorder={vi.fn()} />
+      <Column status="To Do" items={items} onDrop={onDrop} onReorder={vi.fn()} sortMode="custom" />
     );
     const card = container.querySelector('[data-item-id]') as HTMLElement;
 
@@ -437,23 +438,111 @@ describe('Column sort mode (Issue #157)', () => {
   });
 });
 
-describe('Reorder blocked in date-sort mode (Issue #157)', () => {
+describe('Intra-column drag in date-sorted column switches to custom (Issue #161 AC1)', () => {
   afterEach(() => {
     cardMock.currentDragStatus = null;
   });
 
-  it('AC4: drag reorder within column is blocked when sorted by date, shows toast', async () => {
+  it('AC1: drag reorder within date-sorted column calls onSortChange to custom + onReorder + shows undo toast', async () => {
     cardMock.currentDragStatus = 'To Do';
     const onReorder = vi.fn();
+    const onSortChange = vi.fn();
     const items = [
-      makeItem({ id: '1', title: 'Task 1', status: 'To Do', due_date: '2026-03-01' }),
-      makeItem({ id: '2', title: 'Task 2', status: 'To Do', due_date: '2026-06-01' }),
+      makeItem({ id: '1', title: 'Task 1', status: 'To Do', due_date: '2026-03-01', sort_order: 1 }),
+      makeItem({ id: '2', title: 'Task 2', status: 'To Do', due_date: '2026-06-01', sort_order: 2 }),
     ];
     const { container } = render(
-      <Column status="To Do" items={items} onDrop={vi.fn()} onReorder={onReorder} sortMode="due_date" />
+      <Column status="To Do" items={items} onDrop={vi.fn()} onReorder={onReorder} sortMode="due_date" onSortChange={onSortChange} />
     );
 
-    const card = container.querySelector('.card') as HTMLElement;
+    // Drop item '2' (index 1) onto firstCard (index 0) above midpoint → newIndex 0
+    const firstCard = container.querySelectorAll('[data-item-id]')[0] as HTMLElement;
+    const rectSpy = vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+      top: 100, bottom: 300, height: 200, left: 0, right: 100, width: 100,
+      x: 0, y: 100, toJSON: () => ({}),
+    });
+
+    const event = new Event('drop', { bubbles: true }) as any;
+    event.clientY = 100; // above midpoint → index 0
+    event.dataTransfer = {
+      getData: (type: string) => {
+        if (type === 'text/plain') return '2';
+        if (type === 'application/x-hive-status') return 'To Do';
+        return '';
+      },
+    };
+
+    await act(() => {
+      firstCard.dispatchEvent(event);
+    });
+
+    // Should switch to custom sort
+    expect(onSortChange).toHaveBeenCalledWith('custom');
+    // Should perform the reorder (item 2 was at index 1, dropped at index 0)
+    expect(onReorder).toHaveBeenCalledWith('2', 0, items);
+    // Should show undo toast with 10s duration
+    expect(mockShowToast).toHaveBeenCalledWith(
+      'Switched to custom order',
+      'success',
+      expect.objectContaining({ label: 'Undo' }),
+      10000
+    );
+    rectSpy.mockRestore();
+  });
+
+  it('AC2: no-op drag (same position) does not switch sort mode', async () => {
+    cardMock.currentDragStatus = 'To Do';
+    const onReorder = vi.fn();
+    const onSortChange = vi.fn();
+    const items = [
+      makeItem({ id: '1', title: 'Task 1', status: 'To Do', sort_order: 1 }),
+      makeItem({ id: '2', title: 'Task 2', status: 'To Do', sort_order: 2 }),
+    ];
+    const { container } = render(
+      <Column status="To Do" items={items} onDrop={vi.fn()} onReorder={onReorder} sortMode="due_date" onSortChange={onSortChange} />
+    );
+
+    const firstCard = container.querySelectorAll('[data-item-id]')[0] as HTMLElement;
+    const rectSpy = vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+      top: 100, bottom: 300, height: 200, left: 0, right: 100, width: 100,
+      x: 0, y: 100, toJSON: () => ({}),
+    });
+
+    const event = new Event('drop', { bubbles: true }) as any;
+    event.clientY = 100; // above midpoint → index 0, same as source index
+    event.dataTransfer = {
+      getData: (type: string) => {
+        if (type === 'text/plain') return '1'; // item at index 0
+        if (type === 'application/x-hive-status') return 'To Do';
+        return '';
+      },
+    };
+
+    await act(() => {
+      firstCard.dispatchEvent(event);
+    });
+
+    // No sort change, no reorder, no toast
+    expect(onSortChange).not.toHaveBeenCalled();
+    expect(onReorder).not.toHaveBeenCalled();
+    expect(mockShowToast).not.toHaveBeenCalled();
+    rectSpy.mockRestore();
+  });
+
+  it('AC3: undo action in toast reverts to previous sort mode', async () => {
+    cardMock.currentDragStatus = 'To Do';
+    const onReorder = vi.fn();
+    const onSortChange = vi.fn();
+    const items = [
+      makeItem({ id: '1', title: 'Task 1', status: 'To Do', sort_order: 1 }),
+      makeItem({ id: '2', title: 'Task 2', status: 'To Do', sort_order: 2 }),
+    ];
+    const { container } = render(
+      <Column status="To Do" items={items} onDrop={vi.fn()} onReorder={onReorder} sortMode="created" onSortChange={onSortChange} />
+    );
+
+    // Drop item '2' (index 1) onto firstCard (index 0) to trigger sort switch
+    const firstCard = container.querySelectorAll('[data-item-id]')[0] as HTMLElement;
     const rectSpy = vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
       top: 100, bottom: 300, height: 200, left: 0, right: 100, width: 100,
       x: 0, y: 100, toJSON: () => ({}),
@@ -470,22 +559,33 @@ describe('Reorder blocked in date-sort mode (Issue #157)', () => {
     };
 
     await act(() => {
-      card.dispatchEvent(event);
+      firstCard.dispatchEvent(event);
     });
 
-    expect(onReorder).not.toHaveBeenCalled();
-    expect(mockShowToast).toHaveBeenCalledWith('Reorder by drag is disabled when sorted by date', 'error');
+    // Extract the undo function from the toast call
+    const toastCall = mockShowToast.mock.calls[0];
+    const action = toastCall[2] as { label: string; fn: () => void };
+    expect(action.label).toBe('Undo');
+
+    // Call undo — should revert to 'created'
+    onSortChange.mockReset();
+    action.fn();
+    expect(onSortChange).toHaveBeenCalledWith('created');
+
     rectSpy.mockRestore();
   });
+});
 
-  it('AC5: keyboard reorder (Alt+ArrowDown) is blocked when sorted by date, shows toast', async () => {
+describe('Keyboard reorder in date-sorted column switches to custom (Issue #161 AC5)', () => {
+  it('AC5: Alt+ArrowDown in date-sorted column switches to custom, reorders, shows undo toast', async () => {
     const onReorder = vi.fn();
+    const onSortChange = vi.fn();
     const items = [
       makeItem({ id: '1', title: 'Task 1', status: 'To Do', sort_order: 1 }),
       makeItem({ id: '2', title: 'Task 2', status: 'To Do', sort_order: 2 }),
     ];
     const { container } = render(
-      <Column status="To Do" items={items} onDrop={vi.fn()} onReorder={onReorder} sortMode="due_date" />
+      <Column status="To Do" items={items} onDrop={vi.fn()} onReorder={onReorder} sortMode="due_date" onSortChange={onSortChange} />
     );
 
     const titleBtn = container.querySelector('[data-item-id="1"] .card-title') as HTMLElement;
@@ -493,18 +593,25 @@ describe('Reorder blocked in date-sort mode (Issue #157)', () => {
       fireEvent.keyDown(titleBtn, { key: 'ArrowDown', altKey: true });
     });
 
-    expect(onReorder).not.toHaveBeenCalled();
-    expect(mockShowToast).toHaveBeenCalledWith('Reorder by drag is disabled when sorted by date', 'error');
+    expect(onSortChange).toHaveBeenCalledWith('custom');
+    expect(onReorder).toHaveBeenCalledWith('1', 1, items);
+    expect(mockShowToast).toHaveBeenCalledWith(
+      'Switched to custom order',
+      'success',
+      expect.objectContaining({ label: 'Undo' }),
+      10000
+    );
   });
 
-  it('AC5: keyboard reorder (Alt+ArrowUp) is blocked when sorted by date, shows toast', async () => {
+  it('AC5: Alt+ArrowUp in date-sorted column switches to custom', async () => {
     const onReorder = vi.fn();
+    const onSortChange = vi.fn();
     const items = [
       makeItem({ id: '1', title: 'Task 1', status: 'To Do', sort_order: 1 }),
       makeItem({ id: '2', title: 'Task 2', status: 'To Do', sort_order: 2 }),
     ];
     const { container } = render(
-      <Column status="To Do" items={items} onDrop={vi.fn()} onReorder={onReorder} sortMode="created" />
+      <Column status="To Do" items={items} onDrop={vi.fn()} onReorder={onReorder} sortMode="created" onSortChange={onSortChange} />
     );
 
     const titleBtn = container.querySelector('[data-item-id="2"] .card-title') as HTMLElement;
@@ -512,18 +619,19 @@ describe('Reorder blocked in date-sort mode (Issue #157)', () => {
       fireEvent.keyDown(titleBtn, { key: 'ArrowUp', altKey: true });
     });
 
-    expect(onReorder).not.toHaveBeenCalled();
-    expect(mockShowToast).toHaveBeenCalledWith('Reorder by drag is disabled when sorted by date', 'error');
+    expect(onSortChange).toHaveBeenCalledWith('custom');
+    expect(onReorder).toHaveBeenCalledWith('2', 0, items);
   });
 
   it('keyboard reorder works normally in custom sort mode', async () => {
     const onReorder = vi.fn();
+    const onSortChange = vi.fn();
     const items = [
       makeItem({ id: '1', title: 'Task 1', status: 'To Do', sort_order: 1 }),
       makeItem({ id: '2', title: 'Task 2', status: 'To Do', sort_order: 2 }),
     ];
     const { container } = render(
-      <Column status="To Do" items={items} onDrop={vi.fn()} onReorder={onReorder} sortMode="custom" />
+      <Column status="To Do" items={items} onDrop={vi.fn()} onReorder={onReorder} sortMode="custom" onSortChange={onSortChange} />
     );
 
     const titleBtn = container.querySelector('[data-item-id="1"] .card-title') as HTMLElement;
@@ -532,6 +640,236 @@ describe('Reorder blocked in date-sort mode (Issue #157)', () => {
     });
 
     expect(onReorder).toHaveBeenCalledWith('1', 1, items);
+    expect(onSortChange).not.toHaveBeenCalled();
+    expect(mockShowToast).not.toHaveBeenCalled();
+  });
+});
+
+describe('Cross-column drag overlay for date-sorted columns (Issue #161 AC7/AC8)', () => {
+  afterEach(() => {
+    cardMock.currentDragStatus = null;
+  });
+
+  it('AC7: shows overlay with due date message when cross-column dragging into due_date-sorted column', async () => {
+    cardMock.currentDragStatus = 'In Progress';
+    const items = [
+      makeItem({ id: '1', title: 'Task 1', status: 'To Do' }),
+    ];
+    const { container } = render(
+      <Column status="To Do" items={items} onDrop={vi.fn()} onReorder={vi.fn()} sortMode="due_date" />
+    );
+    const card = container.querySelector('.card') as HTMLElement;
+
+    await act(() => {
+      fireEvent.dragOver(card, { bubbles: true, clientY: 110 });
+    });
+
+    const overlay = container.querySelector('.column-date-sort-overlay') as HTMLElement;
+    expect(overlay).not.toBeNull();
+    expect(overlay.textContent).toBe('Will be sorted by due date');
+  });
+
+  it('AC7: shows overlay with creation date message for created-sorted column', async () => {
+    cardMock.currentDragStatus = 'In Progress';
+    const items = [
+      makeItem({ id: '1', title: 'Task 1', status: 'To Do' }),
+    ];
+    const { container } = render(
+      <Column status="To Do" items={items} onDrop={vi.fn()} onReorder={vi.fn()} sortMode="created" />
+    );
+    const card = container.querySelector('.card') as HTMLElement;
+
+    await act(() => {
+      fireEvent.dragOver(card, { bubbles: true, clientY: 110 });
+    });
+
+    const overlay = container.querySelector('.column-date-sort-overlay') as HTMLElement;
+    expect(overlay).not.toBeNull();
+    expect(overlay.textContent).toBe('Will be sorted by creation date');
+  });
+
+  it('AC8: shows overlay with completion date message for Done column', async () => {
+    cardMock.currentDragStatus = 'To Do';
+    const items = [
+      makeItem({ id: '1', title: 'Task 1', status: 'Done' }),
+    ];
+    const { container } = render(
+      <Column status="Done" items={items} onDrop={vi.fn()} onReorder={vi.fn()} />
+    );
+    const card = container.querySelector('.card') as HTMLElement;
+
+    await act(() => {
+      fireEvent.dragOver(card, { bubbles: true, clientY: 110 });
+    });
+
+    const overlay = container.querySelector('.column-date-sort-overlay') as HTMLElement;
+    expect(overlay).not.toBeNull();
+    expect(overlay.textContent).toBe('Will be sorted by completion date');
+  });
+
+  it('AC7: suppresses drop indicators when showing overlay', async () => {
+    cardMock.currentDragStatus = 'In Progress';
+    const items = [
+      makeItem({ id: '1', title: 'Task 1', status: 'To Do' }),
+    ];
+    const { container } = render(
+      <Column status="To Do" items={items} onDrop={vi.fn()} onReorder={vi.fn()} sortMode="due_date" />
+    );
+    const card = container.querySelector('.card') as HTMLElement;
+
+    await act(() => {
+      fireEvent.dragOver(card, { bubbles: true, clientY: 110 });
+    });
+
+    // Overlay present, no drop indicators
+    expect(container.querySelector('.column-date-sort-overlay')).not.toBeNull();
+    expect(container.querySelector('.drop-indicator')).toBeNull();
+  });
+
+  it('AC7: overlay disappears when pointer leaves the column', async () => {
+    cardMock.currentDragStatus = 'In Progress';
+    const items = [
+      makeItem({ id: '1', title: 'Task 1', status: 'To Do' }),
+    ];
+    const { container } = render(
+      <Column status="To Do" items={items} onDrop={vi.fn()} onReorder={vi.fn()} sortMode="due_date" />
+    );
+    const column = container.querySelector('.column') as HTMLElement;
+    const card = container.querySelector('.card') as HTMLElement;
+
+    // Show overlay
+    await act(() => {
+      fireEvent.dragOver(card, { bubbles: true, clientY: 110 });
+    });
+    expect(container.querySelector('.column-date-sort-overlay')).not.toBeNull();
+
+    // Leave column
+    await act(() => {
+      fireEvent.dragLeave(column, { relatedTarget: null });
+    });
+    expect(container.querySelector('.column-date-sort-overlay')).toBeNull();
+  });
+
+  it('no overlay for same-column drag in date-sorted column', async () => {
+    cardMock.currentDragStatus = 'To Do';
+    const items = [
+      makeItem({ id: '1', title: 'Task 1', status: 'To Do' }),
+    ];
+    const { container } = render(
+      <Column status="To Do" items={items} onDrop={vi.fn()} onReorder={vi.fn()} sortMode="due_date" />
+    );
+    const card = container.querySelector('.card') as HTMLElement;
+
+    await act(() => {
+      fireEvent.dragOver(card, { bubbles: true, clientY: 110 });
+    });
+
+    // No overlay for same-column drag (AC1 handles this differently)
+    expect(container.querySelector('.column-date-sort-overlay')).toBeNull();
+  });
+
+  it('no overlay for cross-column drag into custom-sorted column', async () => {
+    cardMock.currentDragStatus = 'In Progress';
+    const items = [
+      makeItem({ id: '1', title: 'Task 1', status: 'To Do' }),
+    ];
+    const { container } = render(
+      <Column status="To Do" items={items} onDrop={vi.fn()} onReorder={vi.fn()} sortMode="custom" />
+    );
+    const card = container.querySelector('.card') as HTMLElement;
+    card.getBoundingClientRect = () => ({
+      top: 100, bottom: 150, height: 50, left: 0, right: 100, width: 100,
+      x: 0, y: 100, toJSON: () => ({}),
+    });
+
+    await act(() => {
+      fireEvent.dragOver(card, { bubbles: true, clientY: 110 });
+    });
+
+    expect(container.querySelector('.column-date-sort-overlay')).toBeNull();
+  });
+});
+
+describe('Cross-column drop into date-sorted column (Issue #161 AC9)', () => {
+  afterEach(() => {
+    cardMock.currentDragStatus = null;
+  });
+
+  it('AC9: cross-column drop into date-sorted column calls onDrop without targetIndex', async () => {
+    cardMock.currentDragStatus = 'In Progress';
+    const onDrop = vi.fn();
+    const items = [
+      makeItem({ id: '1', title: 'Task 1', status: 'To Do' }),
+    ];
+    const { container } = render(
+      <Column status="To Do" items={items} onDrop={onDrop} onReorder={vi.fn()} sortMode="due_date" />
+    );
+    const column = container.querySelector('.column') as HTMLElement;
+
+    await act(() => {
+      fireEvent.drop(column, {
+        bubbles: true,
+        clientY: 500,
+        dataTransfer: {
+          getData: (type: string) => {
+            if (type === 'text/plain') return 'drag-item';
+            if (type === 'application/x-hive-status') return 'In Progress';
+            return '';
+          },
+        },
+      });
+    });
+
+    // Called without targetIndex — date-sorted column places at end
+    expect(onDrop).toHaveBeenCalledWith('drag-item', 'To Do');
+  });
+
+  it('AC9: cross-column drop into Done column calls onDrop without targetIndex', async () => {
+    cardMock.currentDragStatus = 'To Do';
+    const onDrop = vi.fn();
+    const { container } = render(
+      <Column status="Done" items={[]} onDrop={onDrop} onReorder={vi.fn()} />
+    );
+    const column = container.querySelector('.column') as HTMLElement;
+
+    await act(() => {
+      fireEvent.drop(column, {
+        bubbles: true,
+        clientY: 500,
+        dataTransfer: {
+          getData: (type: string) => {
+            if (type === 'text/plain') return 'drag-item';
+            if (type === 'application/x-hive-status') return 'To Do';
+            return '';
+          },
+        },
+      });
+    });
+
+    expect(onDrop).toHaveBeenCalledWith('drag-item', 'Done');
+  });
+
+  it('AC9: no undo toast on cross-column drop into date-sorted column', async () => {
+    cardMock.currentDragStatus = 'In Progress';
+    const { container } = render(
+      <Column status="To Do" items={[]} onDrop={vi.fn()} onReorder={vi.fn()} sortMode="due_date" />
+    );
+    const column = container.querySelector('.column') as HTMLElement;
+
+    await act(() => {
+      fireEvent.drop(column, {
+        bubbles: true,
+        clientY: 500,
+        dataTransfer: {
+          getData: (type: string) => {
+            if (type === 'text/plain') return 'drag-item';
+            if (type === 'application/x-hive-status') return 'In Progress';
+            return '';
+          },
+        },
+      });
+    });
+
     expect(mockShowToast).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/board/column.tsx
+++ b/frontend/src/components/board/column.tsx
@@ -2,7 +2,7 @@ import { useState } from 'preact/hooks';
 import { Card, currentDragStatus } from './card';
 import type { ItemStatus, ItemWithRow } from '../../api/types';
 import type { SortMode } from '../../state/board-store';
-import { showToast } from '../../state/board-store';
+import { showToast, columnAnnouncement } from '../../state/board-store';
 
 interface Props {
   status: ItemStatus;
@@ -31,6 +31,12 @@ const SORT_LABELS: Record<SortMode, string> = {
   created: 'Created',
 };
 
+const SORT_OVERLAY_TEXT: Record<SortMode, string> = {
+  custom: '',
+  due_date: 'Will be sorted by due date',
+  created: 'Will be sorted by creation date',
+};
+
 const STATUS_COLORS: Record<ItemStatus, string> = {
   'To Do': 'var(--color-todo)',
   'In Progress': 'var(--color-inprogress)',
@@ -40,13 +46,29 @@ const STATUS_COLORS: Record<ItemStatus, string> = {
 export function Column({ status, items, onDrop, onReorder, onMoveStatus, compact, allDoneCount, hasArchived, archiveTriggerRef, onOpenArchive, sortMode, onSortChange }: Props) {
   // Track the insertion indicator position for within-column reorder
   const [dropIndicator, setDropIndicator] = useState<{ index: number; position: 'above' | 'below' } | null>(null);
-  // AC8: aria-live announcement text
+  // aria-live announcement text
   const [sortAnnouncement, setSortAnnouncement] = useState('');
+  // AC7/AC8: Cross-column drag overlay for date-sorted destinations
+  const [showDateSortOverlay, setShowDateSortOverlay] = useState(false);
 
   const isDateSorted = sortMode && sortMode !== 'custom';
+  // Done column is always sorted by completion date
+  const isDateSortedDestination = isDateSorted || status === 'Done';
 
   const handleDragOver = (e: DragEvent) => {
     e.preventDefault();
+
+    // Check if this is a cross-column drag into a date-sorted destination
+    const sourceStatus = currentDragStatus;
+    const isCrossColumn = sourceStatus !== null && sourceStatus !== status;
+
+    if (isCrossColumn && isDateSortedDestination) {
+      // AC7/AC8: Show overlay, suppress drop indicators
+      setShowDateSortOverlay(true);
+      setDropIndicator(null);
+      (e.currentTarget as HTMLElement).classList.remove('column-drag-over');
+      return;
+    }
 
     const target = (e.target as HTMLElement).closest('.card') as HTMLElement;
 
@@ -79,6 +101,7 @@ export function Column({ status, items, onDrop, onReorder, onMoveStatus, compact
     const column = e.currentTarget as HTMLElement;
     if (!relatedTarget || !column.contains(relatedTarget)) {
       setDropIndicator(null);
+      setShowDateSortOverlay(false);
       column.classList.remove('column-drag-over');
     }
   };
@@ -87,6 +110,7 @@ export function Column({ status, items, onDrop, onReorder, onMoveStatus, compact
     e.preventDefault();
     (e.currentTarget as HTMLElement).classList.remove('column-drag-over');
     setDropIndicator(null);
+    setShowDateSortOverlay(false);
 
     const itemId = e.dataTransfer?.getData('text/plain');
     const sourceStatus = e.dataTransfer?.getData('application/x-hive-status');
@@ -94,9 +118,41 @@ export function Column({ status, items, onDrop, onReorder, onMoveStatus, compact
 
     // Same-column reorder
     if (sourceStatus === status) {
-      // AC4: If column is in date-sort mode, same-column drag is a no-op
+      // AC1: If column is in date-sort mode, switch to custom sort
       if (isDateSorted) {
-        showToast('Reorder by drag is disabled when sorted by date', 'error');
+        const previousMode = sortMode!;
+        // Compute new index for the dropped card
+        const target = (e.target as HTMLElement).closest('.card') as HTMLElement;
+        const sourceIndex = items.findIndex(i => i.id === itemId);
+        let newIndex = sourceIndex;
+        if (target) {
+          const targetId = target.getAttribute('data-item-id');
+          const targetIndex = items.findIndex(i => i.id === targetId);
+          if (targetIndex !== -1) {
+            const rect = target.getBoundingClientRect();
+            const midY = rect.top + rect.height / 2;
+            newIndex = e.clientY < midY ? targetIndex : targetIndex + 1;
+            if (sourceIndex !== -1 && sourceIndex < newIndex) {
+              newIndex--;
+            }
+          }
+        }
+        // AC2: No-op if position unchanged
+        if (sourceIndex === newIndex) return;
+        // Switch to custom sort
+        if (onSortChange) onSortChange('custom');
+        // Perform the reorder
+        if (onReorder) {
+          onReorder(itemId, newIndex, items);
+        }
+        // Show undo toast (10s)
+        showToast('Switched to custom order', 'success', {
+          label: 'Undo',
+          fn: () => {
+            if (onSortChange) onSortChange(previousMode);
+          },
+        }, 10000);
+        restoreFocus(itemId);
         return;
       }
       if (onReorder) {
@@ -116,13 +172,20 @@ export function Column({ status, items, onDrop, onReorder, onMoveStatus, compact
             if (sourceIndex !== newIndex) {
               onReorder(itemId, newIndex, items);
             }
-            // AC7: Focus restoration after within-column reorder
+            // Focus restoration after within-column reorder
             restoreFocus(itemId);
             return;
           }
         }
       }
       // Dropped on empty area of same column — no-op
+      return;
+    }
+
+    // AC9: Cross-column drop into date-sorted column — place at end (no targetIndex)
+    if (isDateSortedDestination) {
+      onDrop(itemId, status);
+      restoreFocus(itemId);
       return;
     }
 
@@ -136,19 +199,19 @@ export function Column({ status, items, onDrop, onReorder, onMoveStatus, compact
         const midY = rect.top + rect.height / 2;
         const insertIndex = e.clientY < midY ? targetIndex : targetIndex + 1;
         onDrop(itemId, status, insertIndex);
-        // AC7: Focus restoration after cross-column drop
+        // Focus restoration after cross-column drop
         restoreFocus(itemId);
         return;
       }
     }
 
-    // AC3: Dropped on empty space or empty column — place at end (no targetIndex)
+    // Dropped on empty space or empty column — place at end (no targetIndex)
     onDrop(itemId, status);
-    // AC7: Focus restoration
+    // Focus restoration
     restoreFocus(itemId);
   };
 
-  /** AC7: Restore focus to the moved card's title button after DOM update */
+  /** Restore focus to the moved card's title button after DOM update */
   const restoreFocus = (itemId: string) => {
     requestAnimationFrame(() => {
       const card = document.querySelector(`[data-item-id="${itemId}"]`);
@@ -159,9 +222,23 @@ export function Column({ status, items, onDrop, onReorder, onMoveStatus, compact
 
   const handleKeyboardReorder = (itemId: string, direction: 'up' | 'down') => {
     if (!onReorder) return;
-    // AC5: Block keyboard reorder when date-sorted
+    // AC5: If date-sorted, switch to custom and perform the reorder
     if (isDateSorted) {
-      showToast('Reorder by drag is disabled when sorted by date', 'error');
+      const previousMode = sortMode!;
+      const currentIndex = items.findIndex(i => i.id === itemId);
+      if (currentIndex === -1) return;
+      const newIndex = direction === 'up' ? currentIndex - 1 : currentIndex + 1;
+      if (newIndex < 0 || newIndex >= items.length) return;
+      // Switch to custom sort
+      if (onSortChange) onSortChange('custom');
+      onReorder(itemId, newIndex, items);
+      // Show undo toast (10s)
+      showToast('Switched to custom order', 'success', {
+        label: 'Undo',
+        fn: () => {
+          if (onSortChange) onSortChange(previousMode);
+        },
+      }, 10000);
       return;
     }
     const currentIndex = items.findIndex(i => i.id === itemId);
@@ -173,10 +250,24 @@ export function Column({ status, items, onDrop, onReorder, onMoveStatus, compact
     onReorder(itemId, newIndex, items);
   };
 
+  /** AC6: Handle cross-column keyboard move to date-sorted destination */
+  const handleMoveStatus = (itemId: string, newStatus: ItemStatus) => {
+    if (!onMoveStatus) return;
+    onMoveStatus(itemId, newStatus);
+  };
+
   const handleSortChange = (e: Event) => {
     const mode = (e.currentTarget as HTMLSelectElement).value as SortMode;
     if (onSortChange) onSortChange(mode);
     setSortAnnouncement(`${status} column: sorted by ${SORT_LABELS[mode].toLowerCase()}`);
+  };
+
+  // Determine the overlay text for date-sorted cross-column drag
+  const getOverlayText = (): string => {
+    if (status === 'Done') return 'Will be sorted by completion date';
+    if (sortMode === 'due_date') return SORT_OVERLAY_TEXT.due_date;
+    if (sortMode === 'created') return SORT_OVERLAY_TEXT.created;
+    return '';
   };
 
   return (
@@ -189,13 +280,15 @@ export function Column({ status, items, onDrop, onReorder, onMoveStatus, compact
       onDrop={handleDrop}
       style={{ '--column-color': STATUS_COLORS[status] } as any}
     >
-      {/* AC8: aria-live region for sort change announcements */}
-      <div class="sr-only" aria-live="polite" aria-atomic="true">{sortAnnouncement}</div>
+      {/* aria-live region for sort change and cross-column keyboard move announcements */}
+      <div class="sr-only" aria-live="polite" aria-atomic="true">
+        {columnAnnouncement.value?.status === status ? columnAnnouncement.value.text : sortAnnouncement}
+      </div>
       <div class="column-header">
         <div class="column-header-row">
           <h2>{status}</h2>
           <span class="column-count">{items.length}</span>
-          {/* AC6: Sort selector only in board view (not compact/swimlane) */}
+          {/* Sort selector only in board view (not compact/swimlane) */}
           {!compact && status === 'Done' && (
             <select
               class="column-sort-select"
@@ -229,7 +322,7 @@ export function Column({ status, items, onDrop, onReorder, onMoveStatus, compact
           </button>
         )}
       </div>
-      <div class="column-cards">
+      <div class="column-cards" style={{ position: 'relative' }}>
         {items.map((item, index) => (
           <div key={item.id} class="card-wrapper">
             {dropIndicator && dropIndicator.index === index && dropIndicator.position === 'above' && (
@@ -237,7 +330,7 @@ export function Column({ status, items, onDrop, onReorder, onMoveStatus, compact
             )}
             <Card
               item={item}
-              onMoveStatus={onMoveStatus}
+              onMoveStatus={handleMoveStatus}
               onReorder={handleKeyboardReorder}
               columnItems={items}
             />
@@ -248,6 +341,12 @@ export function Column({ status, items, onDrop, onReorder, onMoveStatus, compact
         ))}
         {items.length === 0 && (
           <div class="column-empty">No items</div>
+        )}
+        {/* AC7/AC8: Date-sort overlay for cross-column drag */}
+        {showDateSortOverlay && (
+          <div class="column-date-sort-overlay">
+            {getOverlayText()}
+          </div>
         )}
       </div>
     </div>

--- a/frontend/src/components/board/kanban-board.test.tsx
+++ b/frontend/src/components/board/kanban-board.test.tsx
@@ -106,6 +106,7 @@ vi.mock('../../state/board-store', () => ({
     },
   },
   setColumnSortMode: () => {},
+  columnAnnouncement: { value: null },
 }));
 
 const mockMoveItem = vi.fn();

--- a/frontend/src/components/board/kanban-board.tsx
+++ b/frontend/src/components/board/kanban-board.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useMemo, useEffect } from 'preact/hooks';
 import { useAuth } from '../../auth/auth-context';
-import { columns, showCreateModal, selectedItem, groupBy, rootItems, items, owners, labels as labelsStore, viewMode, setViewMode, allDoneItems, hasArchivedItems, showArchiveDialog, boards, showCreateBoardModal, showShareModal, showDeleteBoardModal, showMoveToBoardModal, boardItems, userBoardRole, accessibleBoards, switchBoard, theme, applyTheme, cycleTheme, columnSortModes, setColumnSortMode } from '../../state/board-store';
+import { columns, showCreateModal, selectedItem, groupBy, rootItems, items, owners, labels as labelsStore, viewMode, setViewMode, allDoneItems, hasArchivedItems, showArchiveDialog, boards, showCreateBoardModal, showShareModal, showDeleteBoardModal, showMoveToBoardModal, boardItems, userBoardRole, accessibleBoards, switchBoard, theme, applyTheme, cycleTheme, columnSortModes, setColumnSortMode, columnAnnouncement } from '../../state/board-store';
 import type { SortMode } from '../../state/board-store';
 import { moveItem, reorderItem } from '../../state/actions';
 import { useKeyboardShortcuts } from '../../hooks/use-keyboard-shortcuts';
@@ -142,6 +142,20 @@ export function KanbanBoard() {
 
   const handleMoveStatus = (itemId: string, newStatus: ItemStatus) => {
     if (token) {
+      // AC6: Announce placement when keyboard-moving into a date-sorted destination
+      const destSortMode = columnSortModes.value[newStatus];
+      const isDestDateSorted = (destSortMode && destSortMode !== 'custom') || newStatus === 'Done';
+      if (isDestDateSorted) {
+        const sortLabel = newStatus === 'Done' ? 'completion date'
+          : destSortMode === 'due_date' ? 'due date'
+          : 'creation date';
+        columnAnnouncement.value = {
+          status: newStatus,
+          text: `Moving to ${newStatus} — will be added in ${sortLabel} order`,
+        };
+        // Clear after screen reader has time to read
+        setTimeout(() => { columnAnnouncement.value = null; }, 3000);
+      }
       moveItem(itemId, newStatus, user?.name || 'web', token);
     }
   };

--- a/frontend/src/components/shared/toast.test.tsx
+++ b/frontend/src/components/shared/toast.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
-import { render, cleanup } from '@testing-library/preact';
+import { render, cleanup, fireEvent, act } from '@testing-library/preact';
 import { Toast } from './toast';
 
 afterEach(() => {
@@ -7,13 +7,20 @@ afterEach(() => {
 });
 
 // Provide a mutable reference for the mock
-let mockToastMessage: { text: string; type: 'success' | 'error' } | null = null;
+let mockToastMessage: { text: string; type: 'success' | 'error'; action?: { label: string; fn: () => void }; duration?: number } | null = null;
+
+const mockPauseToastTimer = vi.fn();
+const mockResumeToastTimer = vi.fn();
+const mockDismissToast = vi.fn();
 
 vi.mock('../../state/board-store', () => ({
   toastMessage: {
     get value() { return mockToastMessage; },
   },
   openDetailWithTitleEdit: { value: false },
+  pauseToastTimer: (...args: unknown[]) => mockPauseToastTimer(...args),
+  resumeToastTimer: (...args: unknown[]) => mockResumeToastTimer(...args),
+  dismissToast: (...args: unknown[]) => mockDismissToast(...args),
 }));
 
 describe('Toast ARIA roles (Issue #7)', () => {
@@ -21,27 +28,26 @@ describe('Toast ARIA roles (Issue #7)', () => {
     mockToastMessage = null;
   });
 
-  it('has role="status" when visible', () => {
+  it('has role="status" on inner aria-live region when visible', () => {
     mockToastMessage = { text: 'Item saved', type: 'success' };
     const { container } = render(<Toast />);
-    const toast = container.querySelector('.toast') as HTMLElement;
-    expect(toast).not.toBeNull();
-    expect(toast.getAttribute('role')).toBe('status');
+    const liveRegion = container.querySelector('[role="status"]') as HTMLElement;
+    expect(liveRegion).not.toBeNull();
+    expect(liveRegion.textContent).toBe('Item saved');
   });
 
-  it('has aria-live="polite" when visible', () => {
+  it('has aria-live="polite" on inner region when visible', () => {
     mockToastMessage = { text: 'Item saved', type: 'success' };
     const { container } = render(<Toast />);
-    const toast = container.querySelector('.toast') as HTMLElement;
-    expect(toast.getAttribute('aria-live')).toBe('polite');
+    const liveRegion = container.querySelector('[aria-live="polite"]') as HTMLElement;
+    expect(liveRegion).not.toBeNull();
   });
 
-  it('renders empty .toast element when there is no message (AC6: pre-rendered)', () => {
+  it('renders empty .toast element when there is no message (pre-rendered)', () => {
     mockToastMessage = null;
     const { container } = render(<Toast />);
     const toast = container.querySelector('.toast') as HTMLElement;
     expect(toast).not.toBeNull();
-    expect(toast.textContent).toBe('');
     expect(toast.classList.contains('toast-empty')).toBe(true);
   });
 });
@@ -59,24 +65,26 @@ describe('Toast pre-rendered (Issue #157 AC6)', () => {
 
   it('has role="status" and aria-live="polite" even when empty', () => {
     const { container } = render(<Toast />);
-    const toast = container.querySelector('.toast') as HTMLElement;
-    expect(toast.getAttribute('role')).toBe('status');
-    expect(toast.getAttribute('aria-live')).toBe('polite');
+    const liveRegion = container.querySelector('[role="status"]') as HTMLElement;
+    expect(liveRegion).not.toBeNull();
+    expect(liveRegion.getAttribute('aria-live')).toBe('polite');
   });
 
   it('updates text in-place when message fires (no mount/unmount)', () => {
     mockToastMessage = null;
     const { container, rerender } = render(<Toast />);
     const toastBefore = container.querySelector('.toast') as HTMLElement;
-    expect(toastBefore.textContent).toBe('');
+    const liveRegion = toastBefore.querySelector('[role="status"]') as HTMLElement;
+    expect(liveRegion.textContent).toBe('');
 
     // Fire a message
     mockToastMessage = { text: 'Item created', type: 'success' };
     rerender(<Toast />);
 
     const toastAfter = container.querySelector('.toast') as HTMLElement;
-    expect(toastAfter.textContent).toBe('Item created');
-    // Same DOM element — updated in-place
+    const liveRegionAfter = toastAfter.querySelector('[role="status"]') as HTMLElement;
+    expect(liveRegionAfter.textContent).toBe('Item created');
+    // Same outer DOM element — updated in-place
     expect(toastAfter).toBe(toastBefore);
   });
 
@@ -92,5 +100,162 @@ describe('Toast pre-rendered (Issue #157 AC6)', () => {
     const { container } = render(<Toast />);
     const toast = container.querySelector('.toast') as HTMLElement;
     expect(toast.classList.contains('toast-error')).toBe(true);
+  });
+});
+
+describe('Toast action button (Issue #161 AC1/AC3)', () => {
+  beforeEach(() => {
+    mockToastMessage = null;
+    mockDismissToast.mockReset();
+  });
+
+  it('renders an Undo button when action is provided', () => {
+    const fn = vi.fn();
+    mockToastMessage = { text: 'Switched to custom order', type: 'success', action: { label: 'Undo', fn }, duration: 10000 };
+    const { container } = render(<Toast />);
+    const btn = container.querySelector('.toast-action') as HTMLButtonElement;
+    expect(btn).not.toBeNull();
+    expect(btn.textContent).toBe('Undo');
+  });
+
+  it('does NOT render action button when no action', () => {
+    mockToastMessage = { text: 'Simple toast', type: 'success' };
+    const { container } = render(<Toast />);
+    const btn = container.querySelector('.toast-action');
+    expect(btn).toBeNull();
+  });
+
+  it('action button is OUTSIDE the aria-live region', () => {
+    const fn = vi.fn();
+    mockToastMessage = { text: 'Switched', type: 'success', action: { label: 'Undo', fn }, duration: 10000 };
+    const { container } = render(<Toast />);
+    const liveRegion = container.querySelector('[role="status"]') as HTMLElement;
+    const btn = container.querySelector('.toast-action') as HTMLButtonElement;
+    expect(liveRegion.contains(btn)).toBe(false);
+  });
+
+  it('clicking action button calls fn and dismisses toast', () => {
+    const fn = vi.fn();
+    mockToastMessage = { text: 'Switched', type: 'success', action: { label: 'Undo', fn }, duration: 10000 };
+    const { container } = render(<Toast />);
+    const btn = container.querySelector('.toast-action') as HTMLButtonElement;
+
+    fireEvent.click(btn);
+
+    expect(fn).toHaveBeenCalledOnce();
+    expect(mockDismissToast).toHaveBeenCalledOnce();
+  });
+});
+
+describe('Toast U key shortcut (Issue #161 AC3)', () => {
+  beforeEach(() => {
+    mockToastMessage = null;
+    mockDismissToast.mockReset();
+  });
+
+  it('pressing U key calls action fn and dismisses toast', () => {
+    const fn = vi.fn();
+    mockToastMessage = { text: 'Switched', type: 'success', action: { label: 'Undo', fn }, duration: 10000 };
+    render(<Toast />);
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'u', bubbles: true }));
+    });
+
+    expect(fn).toHaveBeenCalledOnce();
+    expect(mockDismissToast).toHaveBeenCalledOnce();
+  });
+
+  it('U key does not fire when no action toast', () => {
+    mockToastMessage = { text: 'Simple', type: 'success' };
+    render(<Toast />);
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'u', bubbles: true }));
+    });
+
+    expect(mockDismissToast).not.toHaveBeenCalled();
+  });
+
+  it('U key does not fire when typing in an input', () => {
+    const fn = vi.fn();
+    mockToastMessage = { text: 'Switched', type: 'success', action: { label: 'Undo', fn }, duration: 10000 };
+    const { container } = render(
+      <div>
+        <Toast />
+        <input type="text" data-testid="input" />
+      </div>
+    );
+    const input = container.querySelector('input') as HTMLInputElement;
+
+    act(() => {
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'u', bubbles: true }));
+    });
+
+    expect(fn).not.toHaveBeenCalled();
+  });
+});
+
+describe('Toast timer pause/resume (Issue #161 AC4)', () => {
+  beforeEach(() => {
+    mockToastMessage = null;
+    mockPauseToastTimer.mockReset();
+    mockResumeToastTimer.mockReset();
+  });
+
+  it('pauses timer on mouse enter when action is present', () => {
+    const fn = vi.fn();
+    mockToastMessage = { text: 'Switched', type: 'success', action: { label: 'Undo', fn }, duration: 10000 };
+    const { container } = render(<Toast />);
+    const toast = container.querySelector('.toast') as HTMLElement;
+
+    fireEvent.mouseEnter(toast);
+
+    expect(mockPauseToastTimer).toHaveBeenCalledOnce();
+  });
+
+  it('resumes timer on mouse leave when action is present', () => {
+    const fn = vi.fn();
+    mockToastMessage = { text: 'Switched', type: 'success', action: { label: 'Undo', fn }, duration: 10000 };
+    const { container } = render(<Toast />);
+    const toast = container.querySelector('.toast') as HTMLElement;
+
+    fireEvent.mouseEnter(toast);
+    fireEvent.mouseLeave(toast);
+
+    expect(mockResumeToastTimer).toHaveBeenCalledOnce();
+  });
+
+  it('pauses timer on Undo button focus', () => {
+    const fn = vi.fn();
+    mockToastMessage = { text: 'Switched', type: 'success', action: { label: 'Undo', fn }, duration: 10000 };
+    const { container } = render(<Toast />);
+    const btn = container.querySelector('.toast-action') as HTMLButtonElement;
+
+    fireEvent.focus(btn);
+
+    expect(mockPauseToastTimer).toHaveBeenCalled();
+  });
+
+  it('resumes timer on Undo button blur', () => {
+    const fn = vi.fn();
+    mockToastMessage = { text: 'Switched', type: 'success', action: { label: 'Undo', fn }, duration: 10000 };
+    const { container } = render(<Toast />);
+    const btn = container.querySelector('.toast-action') as HTMLButtonElement;
+
+    fireEvent.focus(btn);
+    fireEvent.blur(btn);
+
+    expect(mockResumeToastTimer).toHaveBeenCalled();
+  });
+
+  it('does NOT pause timer on hover when no action', () => {
+    mockToastMessage = { text: 'Simple', type: 'success' };
+    const { container } = render(<Toast />);
+    const toast = container.querySelector('.toast') as HTMLElement;
+
+    fireEvent.mouseEnter(toast);
+
+    expect(mockPauseToastTimer).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/shared/toast.tsx
+++ b/frontend/src/components/shared/toast.tsx
@@ -1,15 +1,90 @@
-import { toastMessage } from '../../state/board-store';
+import { useRef, useEffect } from 'preact/hooks';
+import { toastMessage, pauseToastTimer, resumeToastTimer, dismissToast } from '../../state/board-store';
 
 export function Toast() {
   const msg = toastMessage.value;
+  const remainingRef = useRef(0);
+  const startRef = useRef(0);
+
+  // Track when the toast appears so we know elapsed time for pause/resume
+  useEffect(() => {
+    if (msg) {
+      remainingRef.current = msg.duration ?? 4000;
+      startRef.current = Date.now();
+    }
+  }, [msg?.text, msg?.type]);
+
+  // Global U key shortcut for undo while action toast is visible
+  useEffect(() => {
+    if (!msg?.action) return;
+    const handler = (e: KeyboardEvent) => {
+      // Don't trigger if user is typing in an input/textarea/select
+      const tag = (e.target as HTMLElement).tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+      if (e.key === 'u' || e.key === 'U') {
+        e.preventDefault();
+        msg.action!.fn();
+        dismissToast();
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [msg?.action]);
+
+  const handleMouseEnter = () => {
+    if (!msg?.action) return;
+    const elapsed = Date.now() - startRef.current;
+    remainingRef.current = Math.max(0, remainingRef.current - elapsed);
+    pauseToastTimer();
+  };
+
+  const handleMouseLeave = () => {
+    if (!msg?.action) return;
+    startRef.current = Date.now();
+    resumeToastTimer(remainingRef.current);
+  };
+
+  const handleFocus = () => {
+    if (!msg?.action) return;
+    const elapsed = Date.now() - startRef.current;
+    remainingRef.current = Math.max(0, remainingRef.current - elapsed);
+    pauseToastTimer();
+  };
+
+  const handleBlur = () => {
+    if (!msg?.action) return;
+    startRef.current = Date.now();
+    resumeToastTimer(remainingRef.current);
+  };
+
+  const handleActionClick = () => {
+    if (msg?.action) {
+      msg.action.fn();
+      dismissToast();
+    }
+  };
 
   return (
     <div
       class={msg ? `toast toast-${msg.type}` : 'toast toast-empty'}
-      role="status"
-      aria-live="polite"
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
     >
-      {msg ? msg.text : ''}
+      {/* aria-live region for screen reader announcement — action button is outside */}
+      <div role="status" aria-live="polite">
+        {msg ? msg.text : ''}
+      </div>
+      {msg?.action && (
+        <button
+          class="toast-action"
+          type="button"
+          onClick={handleActionClick}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+        >
+          {msg.action.label}
+        </button>
+      )}
     </div>
   );
 }

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -869,6 +869,21 @@ body {
   display: flex;
   flex-direction: column;
   gap: 8px;
+  position: relative;
+}
+
+.column-date-sort-overlay {
+  position: absolute;
+  inset: 0;
+  background: var(--overlay-4xl);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 13px;
+  pointer-events: none;
+  border-radius: var(--radius);
+  z-index: 10;
 }
 
 .column-empty {
@@ -2391,6 +2406,9 @@ body {
   z-index: 200;
   animation: toast-in 0.3s ease-out;
   box-shadow: var(--shadow-lg);
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }
 
 .toast-empty {
@@ -2400,6 +2418,27 @@ body {
 
 .toast-success { background: var(--color-success); }
 .toast-error { background: var(--color-danger); }
+
+.toast-action {
+  background: rgba(255, 255, 255, 0.25);
+  color: white;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  border-radius: var(--radius);
+  padding: 4px 12px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.toast-action:hover {
+  background: rgba(255, 255, 255, 0.35);
+}
+
+.toast-action:focus-visible {
+  outline: 2px solid white;
+  outline-offset: 2px;
+}
 
 @keyframes toast-in {
   from { opacity: 0; transform: translateX(-50%) translateY(16px); }

--- a/frontend/src/state/board-store.ts
+++ b/frontend/src/state/board-store.ts
@@ -71,7 +71,7 @@ export const selectedItemId = signal<string | null>(null);
 /** When true, CardDetail opens with the title EditableField in edit mode. */
 export const openDetailWithTitleEdit = signal(false);
 export const showCreateModal = signal(false);
-export const toastMessage = signal<{ text: string; type: 'success' | 'error' } | null>(null);
+export const toastMessage = signal<{ text: string; type: 'success' | 'error'; action?: { label: string; fn: () => void }; duration?: number } | null>(null);
 
 // --- View mode (mobile list vs board) ---
 export type ViewMode = 'board' | 'list';
@@ -245,6 +245,9 @@ export function initActiveBoardFromUrl() {
   }
 }
 
+// --- Column announcements (for aria-live cross-column keyboard move) ---
+export const columnAnnouncement = signal<{ status: ItemStatus; text: string } | null>(null);
+
 // --- Column sort ---
 export type SortMode = 'custom' | 'due_date' | 'created';
 
@@ -307,11 +310,49 @@ export const childrenOfSelected = computed(() =>
 
 // --- Helpers ---
 
-export function showToast(text: string, type: 'success' | 'error' = 'success') {
-  toastMessage.value = { text, type };
-  setTimeout(() => {
+/** Timer ID for the current toast auto-dismiss. Exported for pause/resume in Toast component. */
+export let toastTimerId: ReturnType<typeof setTimeout> | null = null;
+
+export function showToast(text: string, type: 'success' | 'error' = 'success', action?: { label: string; fn: () => void }, duration?: number) {
+  // Clear any existing timer
+  if (toastTimerId !== null) {
+    clearTimeout(toastTimerId);
+    toastTimerId = null;
+  }
+  const ms = duration ?? 4000;
+  toastMessage.value = { text, type, action, duration: ms };
+  toastTimerId = setTimeout(() => {
     toastMessage.value = null;
-  }, 4000);
+    toastTimerId = null;
+  }, ms);
+}
+
+/** Pause the toast auto-dismiss timer. Returns remaining ms, or null if no timer. */
+export function pauseToastTimer(): void {
+  if (toastTimerId !== null) {
+    clearTimeout(toastTimerId);
+    toastTimerId = null;
+  }
+}
+
+/** Resume the toast auto-dismiss timer with the given remaining ms. */
+export function resumeToastTimer(remainingMs: number): void {
+  if (toastTimerId !== null) {
+    clearTimeout(toastTimerId);
+  }
+  toastTimerId = setTimeout(() => {
+    toastMessage.value = null;
+    toastTimerId = null;
+  }, remainingMs);
+}
+
+/** Dismiss the current toast immediately and clear any pending timer. */
+export function dismissToast(): void {
+  if (toastTimerId !== null) {
+    clearTimeout(toastTimerId);
+    toastTimerId = null;
+  }
+  toastMessage.value = null;
 }
 
 export function getChildCount(itemId: string): { done: number; total: number } {


### PR DESCRIPTION
## Summary
Replaces the error toast when dragging/reordering in date-sorted columns with a switch-to-custom flow, adds context-aware overlays for cross-column drags into date-sorted destinations, and enhances the toast component with action buttons, timer pause, and keyboard undo.

Closes #161

## Changes
- **`frontend/src/state/board-store.ts`** — Extended `toastMessage` signal to support `action` and `duration` fields; added `pauseToastTimer`, `resumeToastTimer`, `dismissToast` helpers; added `columnAnnouncement` signal for cross-column keyboard move announcements
- **`frontend/src/components/shared/toast.tsx`** — Rewrote to render action button outside aria-live region; added hover/focus timer pause/resume; added global U key undo shortcut
- **`frontend/src/components/board/column.tsx`** — Replaced date-sort error toast with switch-to-custom + 10s undo toast (AC1/AC5); added no-op guard (AC2); added cross-column date-sort overlay (AC7/AC8); cross-column drop into date-sorted columns uses no-targetIndex path (AC9); aria-live announcement for cross-column keyboard moves (AC6)
- **`frontend/src/components/board/kanban-board.tsx`** — Added AC6 announcement logic in `handleMoveStatus`
- **`frontend/src/global.css`** — Added `.toast-action` button styles, `.column-date-sort-overlay` styles, `position: relative` on `.column-cards`

## Testing
- AC1: `AC1: drag reorder within date-sorted column calls onSortChange to custom + onReorder + shows undo toast`
- AC2: `AC2: no-op drag (same position) does not switch sort mode`
- AC3: `AC3: undo action in toast reverts to previous sort mode` + Toast U key + action button tests
- AC4: Toast timer pause on hover/focus tests
- AC5: `AC5: Alt+ArrowDown/Up in date-sorted column switches to custom`
- AC7: Overlay with due date / creation date message + suppresses drop indicators + disappears on leave
- AC8: Done column overlay with completion date message
- AC9: Cross-column drop into date-sorted/Done column calls onDrop without targetIndex

All 889 frontend tests pass, 18 apps-script tests pass, tsc clean, build clean.

## Rules Sync
- [x] Business rules in `frontend/src/state/rules.ts` updated (if applicable) — N/A, purely frontend UI
- [x] Business rules in `apps-script/src/rules.js` updated (if applicable) — N/A
- [x] Both files remain in sync