### PR TITLE
feat: cascade parent status to sub-items

### DIFF
--- a/apps-script/src/items.js
+++ b/apps-script/src/items.js
@@ -96,6 +96,7 @@ function updateItem(id, changes, actor) {
   var row = sheet.getRange(rowNum, 1, 1, ITEM_COLUMN_COUNT).getValues()[0];
   var item = rowToItem(row);
   var allItems = getItems();
+  var originalStatus = item.status; // #162: capture before any changes
 
   // Handle status change with business rules
   if (changes.status && changes.status !== item.status) {
@@ -138,6 +139,26 @@ function updateItem(id, changes, actor) {
 
   var updatedRow = itemToRow(item);
   sheet.getRange(rowNum, 1, 1, ITEM_COLUMN_COUNT).setValues([updatedRow]);
+
+  // #162: Cascade status to children when a parent item's status changes.
+  // Only cascade for root items (no parent_id) that had a status change.
+  if (changes.status && changes.status !== originalStatus && !item.parent_id) {
+    var allItemsForCascade = getItems();
+    var childItems = allItemsForCascade.filter(function(i) { return i.parent_id === id; });
+    for (var c = 0; c < childItems.length; c++) {
+      var child = childItems[c];
+      if (child.status !== changes.status) {
+        var childOldStatus = child.status;
+        var updatedChild = applyStatusSideEffects(child, changes.status);
+        updatedChild.updated_at = isoNow();
+        var childRowNum = findRowByItemId(sheet, child.id);
+        if (childRowNum !== -1) {
+          sheet.getRange(childRowNum, 1, 1, ITEM_COLUMN_COUNT).setValues([itemToRow(updatedChild)]);
+          writeAuditEntry(child.id, 'status_changed', 'status', childOldStatus, changes.status, actor);
+        }
+      }
+    }
+  }
 
   // Check if parent is now ready to complete
   var refreshedItems = getItems();

--- a/apps-script/src/rules.js
+++ b/apps-script/src/rules.js
@@ -13,18 +13,8 @@ function validateStatusTransition(item, newStatus, allItems) {
     }
   }
 
-  // Any → Done: all children must be Done
-  if (newStatus === 'Done') {
-    var children = allItems.filter(function(i) { return i.parent_id === item.id; });
-    var incompleteChildren = children.filter(function(i) { return i.status !== 'Done'; });
-    if (incompleteChildren.length > 0) {
-      var names = incompleteChildren.map(function(c) { return c.title; }).join(', ');
-      return {
-        valid: false,
-        error: 'Cannot mark as Done: ' + incompleteChildren.length + ' sub-task(s) not complete (' + names + ')',
-      };
-    }
-  }
+  // Note: the "all children must be Done" check was removed in #162.
+  // Moving a parent to Done now cascades the status to all children automatically.
 
   // Done → To Do or In Progress: always allowed (reopening)
   return { valid: true };

--- a/apps-script/tests/rules.test.ts
+++ b/apps-script/tests/rules.test.ts
@@ -44,17 +44,8 @@ function validateStatusTransition(
     }
   }
 
-  if (newStatus === 'Done') {
-    const children = allItems.filter(i => i.parent_id === item.id);
-    const incompleteChildren = children.filter(i => i.status !== 'Done');
-    if (incompleteChildren.length > 0) {
-      const names = incompleteChildren.map(c => c.title).join(', ');
-      return {
-        valid: false,
-        error: `Cannot mark as Done: ${incompleteChildren.length} sub-task(s) not complete (${names})`,
-      };
-    }
-  }
+  // Note: the "all children must be Done" check was removed in #162.
+  // Moving a parent to Done now cascades the status to all children automatically.
 
   return { valid: true };
 }
@@ -109,16 +100,14 @@ describe('validateStatusTransition', () => {
     expect(result.valid).toBe(true);
   });
 
-  it('blocks move to Done when children are incomplete', () => {
+  it('#162: allows move to Done when children are incomplete (cascade handles them)', () => {
     const parent = makeItem({ id: 'parent', status: 'In Progress', owner: 'Luke' });
     const child1 = makeItem({ id: 'child-1', title: 'Child 1', parent_id: 'parent', status: 'Done' });
     const child2 = makeItem({ id: 'child-2', title: 'Child 2', parent_id: 'parent', status: 'In Progress' });
     const allItems = [parent, child1, child2];
 
     const result = validateStatusTransition(parent, 'Done', allItems);
-    expect(result.valid).toBe(false);
-    expect(result.error).toContain('1 sub-task(s) not complete');
-    expect(result.error).toContain('Child 2');
+    expect(result.valid).toBe(true);
   });
 
   it('allows move to Done when all children are Done', () => {

--- a/frontend/src/components/board/card.tsx
+++ b/frontend/src/components/board/card.tsx
@@ -150,7 +150,14 @@ export function Card({ item, onMoveStatus, onReorder, columnItems, sortMode }: P
         )}
 
         {childCount.total > 0 && (
-          <div class="card-subtasks">
+          <div
+            class="card-subtasks"
+            role="progressbar"
+            aria-valuenow={childCount.done}
+            aria-valuemin={0}
+            aria-valuemax={childCount.total}
+            aria-label="Sub-task progress"
+          >
             <div
               class="subtask-bar"
               style={{ '--progress': `${(childCount.done / childCount.total) * 100}%` } as any}

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -1744,6 +1744,15 @@ body {
   background: var(--overlay-sm);
 }
 
+/* #162 AC9: Sub-task checkbox meets minimum 44×44px touch target */
+.subtask-item input[type="checkbox"] {
+  min-width: 44px;
+  min-height: 44px;
+  margin: -12px -8px;
+  padding: 0;
+  cursor: pointer;
+}
+
 .subtask-title {
   flex: 1;
   min-width: 0;

--- a/frontend/src/state/actions.test.ts
+++ b/frontend/src/state/actions.test.ts
@@ -70,7 +70,7 @@ vi.mock('../demo/mock-api', () => ({
 }));
 
 import { loadBoard, NotAllowedError, deleteSubtask, reorderSubtasks, createItemWithSubtasks, reorderItem, moveItem } from './actions';
-import { owners, loading, items, activeBoardId, permissions, currentUserEmail } from './board-store';
+import { owners, loading, items, activeBoardId, permissions, currentUserEmail, toastMessage } from './board-store';
 import * as sheetsApi from '../api/sheets';
 import type { ItemWithRow } from '../api/types';
 
@@ -519,5 +519,209 @@ describe('moveItem AC3: cross-column places at bottom', () => {
     const updatedItem = mockUpdateItemRow.mock.calls[0][1];
     expect(updatedItem.sort_order).toBe(1);
     expect(updatedItem.status).toBe('In Progress');
+  });
+});
+
+// --- #162: Status cascade tests ---
+
+describe('moveItem #162: parent status cascades to children', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    toastMessage.value = null;
+  });
+
+  // AC1: Parent moved to In Progress cascades to children
+  it('AC1: cascades In Progress status to all children', async () => {
+    const parent = makeItem({ id: 'parent', title: 'Grocery Shopping', status: 'To Do', owner: 'Luke', sheetRow: 2 });
+    const child1 = makeItem({ id: 'c1', title: 'Buy milk', status: 'To Do', parent_id: 'parent', sheetRow: 3 });
+    const child2 = makeItem({ id: 'c2', title: 'Buy eggs', status: 'To Do', parent_id: 'parent', sheetRow: 4 });
+    const child3 = makeItem({ id: 'c3', title: 'Buy bread', status: 'To Do', parent_id: 'parent', sheetRow: 5 });
+    items.value = [parent, child1, child2, child3];
+    mockFetchAllItems.mockResolvedValue([parent, child1, child2, child3]);
+
+    await moveItem('parent', 'In Progress', 'web', 'test-token');
+
+    // Parent + 3 children = 4 updateItemRow calls
+    expect(mockUpdateItemRow).toHaveBeenCalledTimes(4);
+
+    // Children should be updated to In Progress
+    const child1Update = mockUpdateItemRow.mock.calls[1][1];
+    const child2Update = mockUpdateItemRow.mock.calls[2][1];
+    const child3Update = mockUpdateItemRow.mock.calls[3][1];
+    expect(child1Update.status).toBe('In Progress');
+    expect(child2Update.status).toBe('In Progress');
+    expect(child3Update.status).toBe('In Progress');
+
+    // Audit entries: 1 for parent + 3 for children = 4
+    expect(mockAppendAuditEntry).toHaveBeenCalledTimes(4);
+    expect(mockAppendAuditEntry).toHaveBeenCalledWith('c1', 'status_changed', 'status', 'To Do', 'In Progress', 'web', 'test-token');
+
+    // updated_at should be set on children
+    expect(child1Update.updated_at).toBeTruthy();
+  });
+
+  it('AC1: toast includes cascade count', async () => {
+    const parent = makeItem({ id: 'parent', title: 'Grocery Shopping', status: 'To Do', owner: 'Luke', sheetRow: 2 });
+    const child1 = makeItem({ id: 'c1', title: 'Buy milk', status: 'To Do', parent_id: 'parent', sheetRow: 3 });
+    const child2 = makeItem({ id: 'c2', title: 'Buy eggs', status: 'To Do', parent_id: 'parent', sheetRow: 4 });
+    const child3 = makeItem({ id: 'c3', title: 'Buy bread', status: 'To Do', parent_id: 'parent', sheetRow: 5 });
+    items.value = [parent, child1, child2, child3];
+    mockFetchAllItems.mockResolvedValue([parent, child1, child2, child3]);
+
+    await moveItem('parent', 'In Progress', 'web', 'test-token');
+
+    expect(toastMessage.value?.text).toBe('Grocery Shopping moved to In Progress (3 sub-tasks updated)');
+  });
+
+  // AC2: Parent moved to Done cascades to children (mixed statuses)
+  it('AC2: cascades Done status to children in mixed statuses and sets completed_at', async () => {
+    const parent = makeItem({ id: 'parent', title: 'Project', status: 'In Progress', owner: 'Luke', sheetRow: 2 });
+    const child1 = makeItem({ id: 'c1', title: 'Task A', status: 'To Do', parent_id: 'parent', sheetRow: 3 });
+    const child2 = makeItem({ id: 'c2', title: 'Task B', status: 'In Progress', parent_id: 'parent', sheetRow: 4 });
+    const child3 = makeItem({ id: 'c3', title: 'Task C', status: 'Done', parent_id: 'parent', sheetRow: 5, completed_at: '2025-01-01T00:00:00Z' });
+    items.value = [parent, child1, child2, child3];
+    mockFetchAllItems.mockResolvedValue([parent, child1, child2, child3]);
+
+    await moveItem('parent', 'Done', 'web', 'test-token');
+
+    // Parent + 2 children that aren't already Done = 3 updateItemRow calls
+    expect(mockUpdateItemRow).toHaveBeenCalledTimes(3);
+
+    // Children should now be Done with completed_at set
+    const child1Update = mockUpdateItemRow.mock.calls[1][1];
+    const child2Update = mockUpdateItemRow.mock.calls[2][1];
+    expect(child1Update.status).toBe('Done');
+    expect(child1Update.completed_at).toBeTruthy();
+    expect(child2Update.status).toBe('Done');
+    expect(child2Update.completed_at).toBeTruthy();
+
+    // Toast should say 2 (not 3, since child3 was already Done)
+    expect(toastMessage.value?.text).toBe('Project moved to Done (2 sub-tasks updated)');
+  });
+
+  // AC3: Parent moved backward resets children
+  it('AC3: cascading back to To Do clears completed_at on children', async () => {
+    const parent = makeItem({ id: 'parent', title: 'Task', status: 'Done', owner: 'Luke', sheetRow: 2, completed_at: '2025-01-01T00:00:00Z' });
+    const child1 = makeItem({ id: 'c1', title: 'Sub A', status: 'Done', parent_id: 'parent', sheetRow: 3, completed_at: '2025-01-01T00:00:00Z' });
+    const child2 = makeItem({ id: 'c2', title: 'Sub B', status: 'Done', parent_id: 'parent', sheetRow: 4, completed_at: '2025-01-01T00:00:00Z' });
+    items.value = [parent, child1, child2];
+    mockFetchAllItems.mockResolvedValue([parent, child1, child2]);
+
+    await moveItem('parent', 'To Do', 'web', 'test-token');
+
+    // Parent + 2 children = 3 updateItemRow calls
+    expect(mockUpdateItemRow).toHaveBeenCalledTimes(3);
+
+    // Children should be To Do with cleared completed_at
+    const child1Update = mockUpdateItemRow.mock.calls[1][1];
+    const child2Update = mockUpdateItemRow.mock.calls[2][1];
+    expect(child1Update.status).toBe('To Do');
+    expect(child1Update.completed_at).toBe('');
+    expect(child2Update.status).toBe('To Do');
+    expect(child2Update.completed_at).toBe('');
+
+    expect(toastMessage.value?.text).toBe('Task moved to To Do (2 sub-tasks updated)');
+  });
+
+  // AC4: No cascade when moving a child item directly
+  it('AC4: moving a child item does not cascade to siblings', async () => {
+    const parent = makeItem({ id: 'parent', title: 'Parent', status: 'To Do', owner: 'Luke', sheetRow: 2 });
+    const child1 = makeItem({ id: 'c1', title: 'Sub A', status: 'To Do', parent_id: 'parent', sheetRow: 3 });
+    const child2 = makeItem({ id: 'c2', title: 'Sub B', status: 'To Do', parent_id: 'parent', sheetRow: 4 });
+    items.value = [parent, child1, child2];
+    mockFetchAllItems.mockResolvedValue([parent, child1, child2]);
+
+    await moveItem('c1', 'Done', 'web', 'test-token');
+
+    // Only the child itself should be updated, not the parent or sibling
+    expect(mockUpdateItemRow).toHaveBeenCalledTimes(1);
+    expect(mockUpdateItemRow.mock.calls[0][1].id).toBe('c1');
+    expect(mockUpdateItemRow.mock.calls[0][1].status).toBe('Done');
+
+    // Only 1 audit entry for the child
+    expect(mockAppendAuditEntry).toHaveBeenCalledTimes(1);
+    expect(mockAppendAuditEntry).toHaveBeenCalledWith('c1', 'status_changed', 'status', 'To Do', 'Done', 'web', 'test-token');
+  });
+
+  // AC5: Toast omits cascade count when parent has no children
+  it('AC5: toast has no cascade count for items without children', async () => {
+    const item = makeItem({ id: 'solo', title: 'Solo Task', status: 'To Do', owner: 'Luke', sheetRow: 2 });
+    items.value = [item];
+    mockFetchAllItems.mockResolvedValue([item]);
+
+    await moveItem('solo', 'In Progress', 'web', 'test-token');
+
+    expect(toastMessage.value?.text).toBe('Solo Task moved to In Progress');
+  });
+
+  // AC6: Audit log records child cascades
+  it('AC6: writes audit entries for each cascaded child', async () => {
+    const parent = makeItem({ id: 'parent', title: 'Parent', status: 'To Do', owner: 'Luke', sheetRow: 2 });
+    const child1 = makeItem({ id: 'c1', title: 'Sub A', status: 'To Do', parent_id: 'parent', sheetRow: 3 });
+    const child2 = makeItem({ id: 'c2', title: 'Sub B', status: 'To Do', parent_id: 'parent', sheetRow: 4 });
+    items.value = [parent, child1, child2];
+    mockFetchAllItems.mockResolvedValue([parent, child1, child2]);
+
+    await moveItem('parent', 'In Progress', 'web', 'test-token');
+
+    // Parent audit entry
+    expect(mockAppendAuditEntry).toHaveBeenCalledWith('parent', 'status_changed', 'status', 'To Do', 'In Progress', 'web', 'test-token');
+    // Child audit entries
+    expect(mockAppendAuditEntry).toHaveBeenCalledWith('c1', 'status_changed', 'status', 'To Do', 'In Progress', 'web', 'test-token');
+    expect(mockAppendAuditEntry).toHaveBeenCalledWith('c2', 'status_changed', 'status', 'To Do', 'In Progress', 'web', 'test-token');
+  });
+
+  it('optimistically updates children in items signal so progress bar recomputes', async () => {
+    const parent = makeItem({ id: 'parent', title: 'Parent', status: 'In Progress', owner: 'Luke', sheetRow: 2 });
+    const child1 = makeItem({ id: 'c1', title: 'Sub A', status: 'To Do', parent_id: 'parent', sheetRow: 3 });
+    const child2 = makeItem({ id: 'c2', title: 'Sub B', status: 'In Progress', parent_id: 'parent', sheetRow: 4 });
+    items.value = [parent, child1, child2];
+
+    // Don't resolve fetchAllItems immediately — check optimistic state first
+    let resolveFetch: (value: any) => void;
+    mockFetchAllItems.mockReturnValue(new Promise(r => { resolveFetch = r; }));
+
+    const promise = moveItem('parent', 'Done', 'web', 'test-token');
+
+    // Before API calls resolve, children should already be updated optimistically
+    expect(items.value.find(i => i.id === 'c1')!.status).toBe('Done');
+    expect(items.value.find(i => i.id === 'c2')!.status).toBe('Done');
+    expect(items.value.find(i => i.id === 'parent')!.status).toBe('Done');
+
+    resolveFetch!([parent, child1, child2]);
+    await promise;
+  });
+
+  it('rolls back children on API failure', async () => {
+    const parent = makeItem({ id: 'parent', title: 'Parent', status: 'To Do', owner: 'Luke', sheetRow: 2 });
+    const child1 = makeItem({ id: 'c1', title: 'Sub A', status: 'To Do', parent_id: 'parent', sheetRow: 3 });
+    items.value = [parent, child1];
+
+    mockUpdateItemRow.mockRejectedValue(new Error('Network error'));
+
+    await moveItem('parent', 'In Progress', 'web', 'test-token');
+
+    // Should roll back to original state
+    expect(items.value.find(i => i.id === 'parent')!.status).toBe('To Do');
+    expect(items.value.find(i => i.id === 'c1')!.status).toBe('To Do');
+  });
+
+  it('cascade works with targetIndex (drag-and-drop specific position)', async () => {
+    mockUpdateItemRow.mockResolvedValue(undefined); // reset after rollback test's mockRejectedValue
+    const parent = makeItem({ id: 'parent', title: 'Parent', status: 'To Do', owner: 'Luke', sheetRow: 2 });
+    const child1 = makeItem({ id: 'c1', title: 'Sub A', status: 'To Do', parent_id: 'parent', sheetRow: 3 });
+    const existing = makeItem({ id: 'existing', title: 'Existing', status: 'In Progress', owner: 'Luke', sheetRow: 6, sort_order: 1 });
+    items.value = [parent, child1, existing];
+    mockFetchAllItems.mockResolvedValue([parent, child1, existing]);
+
+    await moveItem('parent', 'In Progress', 'web', 'test-token', 0);
+
+    // updateItemRow: 2 for column renumber (parent + existing) + 1 for cascaded child = 3
+    expect(mockUpdateItemRow).toHaveBeenCalledTimes(3);
+
+    // Child should be cascaded
+    const childCall = mockUpdateItemRow.mock.calls[2][1];
+    expect(childCall.id).toBe('c1');
+    expect(childCall.status).toBe('In Progress');
   });
 });

--- a/frontend/src/state/actions.ts
+++ b/frontend/src/state/actions.ts
@@ -414,6 +414,12 @@ export async function moveItem(
     .filter(i => i.status === newStatus && !i.parent_id && i.id !== itemId)
     .sort((a, b) => a.sort_order - b.sort_order);
 
+  // #162: Cascade — find children to update (only for root items, not sub-tasks)
+  const children = !item.parent_id
+    ? items.value.filter(i => i.parent_id === itemId)
+    : [];
+  const childrenToUpdate = children.filter(c => c.status !== newStatus);
+
   if (targetIndex !== undefined) {
     // AC2: Insert at specific position and renumber the destination column
     const movedItem: ItemWithRow = {
@@ -433,21 +439,41 @@ export async function moveItem(
       updated_at: new Date().toISOString(),
     }));
 
-    // Optimistic update
+    // #162: Apply cascade to children optimistically
+    const cascadedChildren: ItemWithRow[] = childrenToUpdate.map(c => ({
+      ...applyStatusSideEffects(c, newStatus),
+      sheetRow: c.sheetRow,
+    }));
+
+    // Optimistic update (parent column + cascaded children)
     items.value = items.value.map(i => {
-      const updated = updates.find(u => u.id === i.id);
-      return updated ?? i;
+      const colUpdate = updates.find(u => u.id === i.id);
+      if (colUpdate) return colUpdate;
+      const childUpdate = cascadedChildren.find(c => c.id === i.id);
+      if (childUpdate) return childUpdate;
+      return i;
     });
 
-    // AC6: Screen reader announcement with position
+    // AC6: Screen reader announcement with position + cascade count
     const totalInColumn = reordered.length;
-    showToast(`${item.title} moved to ${newStatus}, position ${clampedIndex + 1} of ${totalInColumn}`);
+    const cascadeMsg = childrenToUpdate.length > 0
+      ? ` (${childrenToUpdate.length} sub-task${childrenToUpdate.length !== 1 ? 's' : ''} updated)`
+      : '';
+    showToast(`${item.title} moved to ${newStatus}, position ${clampedIndex + 1} of ${totalInColumn}${cascadeMsg}`);
 
     try {
-      for (const updated of updates) {
-        await updateItemRow(updated.sheetRow, updated, token);
+      for (const u of updates) {
+        await updateItemRow(u.sheetRow, u, token);
       }
       await appendAuditEntry(itemId, 'status_changed', 'status', oldItem.status, newStatus, actor, token);
+
+      // #162: Persist cascade
+      for (const child of cascadedChildren) {
+        await updateItemRow(child.sheetRow, child, token);
+        await appendAuditEntry(child.id, 'status_changed', 'status',
+          childrenToUpdate.find(c => c.id === child.id)!.status, newStatus, actor, token);
+      }
+
       await refreshItems(token);
       return true;
     } catch (err: any) {
@@ -459,7 +485,7 @@ export async function moveItem(
     }
   }
 
-  // AC3: No targetIndex — place item at bottom of target column (sort_order = max + 1)
+  // No targetIndex — place item at bottom of target column (sort_order = max + 1)
   const maxSortOrder = destColumnItems.reduce((max, i) => Math.max(max, i.sort_order), 0);
 
   const updated = {
@@ -468,16 +494,41 @@ export async function moveItem(
     sheetRow: item.sheetRow,
   };
 
-  // Optimistic update
-  items.value = items.value.map(i => i.id === itemId ? updated : i);
+  // #162: Apply cascade to children optimistically
+  const cascadedChildren: ItemWithRow[] = childrenToUpdate.map(c => ({
+    ...applyStatusSideEffects(c, newStatus),
+    sheetRow: c.sheetRow,
+  }));
+
+  // Optimistic update (parent + cascaded children)
+  items.value = items.value.map(i => {
+    if (i.id === itemId) return updated;
+    const childUpdate = cascadedChildren.find(c => c.id === i.id);
+    if (childUpdate) return childUpdate;
+    return i;
+  });
+
+  // #162: Toast with cascade count
+  const cascadeMsg = childrenToUpdate.length > 0
+    ? ` (${childrenToUpdate.length} sub-task${childrenToUpdate.length !== 1 ? 's' : ''} updated)`
+    : '';
+  showToast(`${item.title} moved to ${newStatus}${cascadeMsg}`);
 
   try {
     await updateItemRow(item.sheetRow, updated, token);
     await appendAuditEntry(itemId, 'status_changed', 'status', oldItem.status, newStatus, actor, token);
+
+    // #162: Persist cascade
+    for (const child of cascadedChildren) {
+      await updateItemRow(child.sheetRow, child, token);
+      await appendAuditEntry(child.id, 'status_changed', 'status',
+        childrenToUpdate.find(c => c.id === child.id)!.status, newStatus, actor, token);
+    }
+
     await refreshItems(token);
     return true;
   } catch (err: any) {
-    items.value = items.value.map(i => i.id === itemId ? oldItem : i);
+    items.value = oldItems;
     if (!isReauthFailure(err)) {
       showToast('Failed to move item: ' + err.message, 'error');
     }

--- a/frontend/src/state/rules.ts
+++ b/frontend/src/state/rules.ts
@@ -24,18 +24,8 @@ export function validateStatusTransition(
     }
   }
 
-  // Any → Done: all children must be Done
-  if (newStatus === 'Done') {
-    const children = allItems.filter(i => i.parent_id === item.id);
-    const incompleteChildren = children.filter(i => i.status !== 'Done');
-    if (incompleteChildren.length > 0) {
-      const names = incompleteChildren.map(c => c.title).join(', ');
-      return {
-        valid: false,
-        error: `Cannot mark as Done: ${incompleteChildren.length} sub-task(s) not complete (${names})`,
-      };
-    }
-  }
+  // Note: the "all children must be Done" check was removed in #162.
+  // Moving a parent to Done now cascades the status to all children automatically.
 
   return { valid: true };
 }


### PR DESCRIPTION
## Summary
- When a parent item's status changes, all sub-items automatically cascade to the same status
- Removes the old "all children must be Done" validation gate (cascade makes it unnecessary)
- Works for both drag-and-drop (targetIndex) and keyboard/click (bottom-of-column) moves
- Optimistic UI updates with rollback on failure
- Audit trail entries written for each cascaded child
- ARIA progressbar semantics on sub-task progress indicators
- 44×44px touch target on sub-task checkboxes (WCAG 2.1 AA)
- Business rules kept in sync between frontend and Apps Script

Closes #162

## Test plan
- [x] 899 frontend tests pass (10 new cascade tests)
- [x] 18 Apps Script tests pass (updated validation test)
- [x] TypeScript type check clean
- [x] Production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)