### PR TITLE
fix: date picker calendar icon invisible in dark mode

### DIFF
--- a/frontend/src/components/board/dark-mode-date-picker.test.ts
+++ b/frontend/src/components/board/dark-mode-date-picker.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+
+// @ts-ignore -- Node builtins available at test runtime
+import { readFileSync } from 'fs';
+// @ts-ignore
+import { resolve } from 'path';
+
+// @ts-ignore -- __dirname available in vitest CJS context
+const cssPath = resolve(__dirname, '../../global.css');
+const css = readFileSync(cssPath, 'utf-8');
+
+describe('Dark mode date picker icon visibility (Issue #167)', () => {
+  // AC1 + AC2: Date inputs in dark mode get color-scheme: dark
+  // This single rule covers all date inputs — card detail modal, subtask inline editor,
+  // subtask creation row, and create-item modal.
+  describe('AC1/AC2: dark mode date inputs have color-scheme: dark', () => {
+    it('[data-theme="dark"] input[type="date"] sets color-scheme: dark', () => {
+      // Match the selector and its block content
+      const re = /\[data-theme="dark"\]\s+input\[type="date"\]\s*\{([^}]*)\}/;
+      const match = css.match(re);
+      expect(match).not.toBeNull();
+      expect(match![1]).toContain('color-scheme: dark');
+    });
+  });
+
+  // AC3: Light mode unaffected — no color-scheme override on :root date inputs
+  describe('AC3: light mode date inputs have no color-scheme override', () => {
+    it(':root does not set color-scheme on input[type="date"]', () => {
+      // Ensure there is no :root input[type="date"] { color-scheme } rule
+      const re = /:root\s+input\[type="date"\]\s*\{[^}]*color-scheme/;
+      expect(css).not.toMatch(re);
+    });
+  });
+});

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -106,6 +106,11 @@
   --focus-ring: 0 0 0 2px var(--color-focus);
 }
 
+/* Date inputs: tell the browser to use dark-themed controls in dark mode */
+[data-theme="dark"] input[type="date"] {
+  color-scheme: dark;
+}
+
 /* === Reset === */
 *, *::before, *::after {
   box-sizing: border-box;


### PR DESCRIPTION
## Summary
Fix invisible calendar icon on `input[type="date"]` elements in dark mode by setting `color-scheme: dark` when `[data-theme="dark"]` is active.

Closes #167

## Changes
- **`frontend/src/global.css`** — Added `[data-theme="dark"] input[type="date"] { color-scheme: dark; }` rule after the dark mode token block. This tells the browser to render native date input controls (including the calendar icon) with a light-on-dark colour scheme.
- **`frontend/src/components/board/dark-mode-date-picker.test.ts`** — New CSS source inspection test verifying the rule exists for dark mode and that light mode has no override.

## Testing
- AC1/AC2: Test verifies `[data-theme="dark"] input[type="date"]` block contains `color-scheme: dark`
- AC3: Test verifies no `:root input[type="date"]` color-scheme override exists

## Rules Sync
- [x] Business rules in `frontend/src/state/rules.ts` updated (if applicable) — N/A
- [x] Business rules in `apps-script/src/rules.js` updated (if applicable) — N/A
- [x] Both files remain in sync — N/A (CSS-only change)