### PR TITLE
feat: add inline Add Item button to columns

### DIFF
--- a/frontend/src/components/board/column.test.tsx
+++ b/frontend/src/components/board/column.test.tsx
@@ -873,3 +873,103 @@ describe('Cross-column drop into date-sorted column (Issue #161 AC9)', () => {
     expect(mockShowToast).not.toHaveBeenCalled();
   });
 });
+
+// --- Inline Add Item to Column (Issue #170) ---
+describe('Column — Inline Add Item (Issue #170)', () => {
+  afterEach(() => {
+    cardMock.currentDragStatus = null;
+  });
+
+  // AC1: Header "+" button renders and calls onAddItem
+  it('renders header "+" button with correct aria-label in board view', () => {
+    const onAddItem = vi.fn();
+    const { container } = render(
+      <Column status="To Do" items={[]} onDrop={vi.fn()} onAddItem={onAddItem} />
+    );
+    const addBtn = container.querySelector('.column-add-btn') as HTMLButtonElement;
+    expect(addBtn).not.toBeNull();
+    expect(addBtn.getAttribute('aria-label')).toBe('Add item to To Do');
+  });
+
+  it('header "+" button calls onAddItem when clicked', () => {
+    const onAddItem = vi.fn();
+    const { container } = render(
+      <Column status="In Progress" items={[]} onDrop={vi.fn()} onAddItem={onAddItem} />
+    );
+    const addBtn = container.querySelector('.column-add-btn') as HTMLButtonElement;
+    fireEvent.click(addBtn);
+    expect(onAddItem).toHaveBeenCalledTimes(1);
+  });
+
+  // AC5: No "+" button in compact (swimlane) mode
+  it('does not render header "+" button in compact mode', () => {
+    const onAddItem = vi.fn();
+    const { container } = render(
+      <Column status="To Do" items={[]} onDrop={vi.fn()} onAddItem={onAddItem} compact />
+    );
+    const addBtn = container.querySelector('.column-add-btn');
+    expect(addBtn).toBeNull();
+  });
+
+  // AC2: Hover "Add item" row renders in board view (not compact)
+  it('renders hover "Add item" row in board view', () => {
+    const onAddItem = vi.fn();
+    const { container } = render(
+      <Column status="To Do" items={[]} onDrop={vi.fn()} onAddItem={onAddItem} />
+    );
+    const addRow = container.querySelector('.column-add-row');
+    expect(addRow).not.toBeNull();
+    expect(addRow!.textContent).toContain('Add item');
+  });
+
+  // AC5: No hover row in compact mode
+  it('does not render hover "Add item" row in compact mode', () => {
+    const onAddItem = vi.fn();
+    const { container } = render(
+      <Column status="To Do" items={[]} onDrop={vi.fn()} onAddItem={onAddItem} compact />
+    );
+    const addRow = container.querySelector('.column-add-row');
+    expect(addRow).toBeNull();
+  });
+
+  // AC3: Hover row calls onAddItem when clicked
+  it('hover "Add item" row calls onAddItem when clicked', () => {
+    const onAddItem = vi.fn();
+    const { container } = render(
+      <Column status="Done" items={[]} onDrop={vi.fn()} onAddItem={onAddItem} />
+    );
+    const addRow = container.querySelector('.column-add-row') as HTMLButtonElement;
+    fireEvent.click(addRow);
+    expect(onAddItem).toHaveBeenCalledTimes(1);
+  });
+
+  // AC4: Hover row not rendered during drag
+  it('does not render hover row when a drag is active', () => {
+    cardMock.currentDragStatus = 'To Do';
+    const onAddItem = vi.fn();
+    const { container } = render(
+      <Column status="In Progress" items={[]} onDrop={vi.fn()} onAddItem={onAddItem} />
+    );
+    const addRow = container.querySelector('.column-add-row');
+    expect(addRow).toBeNull();
+  });
+
+  // No onAddItem prop means no button or row
+  it('does not render "+" button or hover row when onAddItem is not provided', () => {
+    const { container } = render(
+      <Column status="To Do" items={[]} onDrop={vi.fn()} />
+    );
+    expect(container.querySelector('.column-add-btn')).toBeNull();
+    expect(container.querySelector('.column-add-row')).toBeNull();
+  });
+
+  // Hover row has tabIndex=-1 (mouse-only)
+  it('hover row has tabIndex=-1 for mouse-only interaction', () => {
+    const onAddItem = vi.fn();
+    const { container } = render(
+      <Column status="To Do" items={[]} onDrop={vi.fn()} onAddItem={onAddItem} />
+    );
+    const addRow = container.querySelector('.column-add-row') as HTMLButtonElement;
+    expect(addRow.tabIndex).toBe(-1);
+  });
+});

--- a/frontend/src/components/board/column.tsx
+++ b/frontend/src/components/board/column.tsx
@@ -23,6 +23,8 @@ interface Props {
   sortMode?: SortMode;
   /** Called when the user selects a new sort mode. */
   onSortChange?: (mode: SortMode) => void;
+  /** Called when the user clicks the "+" header button or the "Add item" hover row. */
+  onAddItem?: () => void;
 }
 
 const SORT_LABELS: Record<SortMode, string> = {
@@ -43,7 +45,7 @@ const STATUS_COLORS: Record<ItemStatus, string> = {
   'Done': 'var(--color-done)',
 };
 
-export function Column({ status, items, onDrop, onReorder, onMoveStatus, compact, allDoneCount, hasArchived, archiveTriggerRef, onOpenArchive, sortMode, onSortChange }: Props) {
+export function Column({ status, items, onDrop, onReorder, onMoveStatus, compact, allDoneCount, hasArchived, archiveTriggerRef, onOpenArchive, sortMode, onSortChange, onAddItem }: Props) {
   // Track the insertion indicator position for within-column reorder
   const [dropIndicator, setDropIndicator] = useState<{ index: number; position: 'above' | 'below' } | null>(null);
   // aria-live announcement text
@@ -288,6 +290,13 @@ export function Column({ status, items, onDrop, onReorder, onMoveStatus, compact
         <div class="column-header-row">
           <h2>{status}</h2>
           <span class="column-count">{items.length}</span>
+          {!compact && onAddItem && (
+            <button
+              class="column-add-btn"
+              onClick={onAddItem}
+              aria-label={`Add item to ${status}`}
+            >+</button>
+          )}
           {/* Sort selector only in board view (not compact/swimlane) */}
           {!compact && status === 'Done' && (
             <select
@@ -341,6 +350,16 @@ export function Column({ status, items, onDrop, onReorder, onMoveStatus, compact
         ))}
         {items.length === 0 && (
           <div class="column-empty">No items</div>
+        )}
+        {/* Hover "Add item" row — only in board view, hidden during drag */}
+        {!compact && onAddItem && !currentDragStatus && (
+          <button
+            class="column-add-row"
+            onClick={onAddItem}
+            tabIndex={-1}
+          >
+            <span class="column-add-row-icon">+</span> Add item
+          </button>
         )}
         {/* AC7/AC8: Date-sort overlay for cross-column drag */}
         {showDateSortOverlay && (

--- a/frontend/src/components/board/kanban-board.tsx
+++ b/frontend/src/components/board/kanban-board.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useMemo, useEffect } from 'preact/hooks';
 import { useAuth } from '../../auth/auth-context';
-import { columns, showCreateModal, selectedItem, groupBy, rootItems, items, owners, labels as labelsStore, viewMode, setViewMode, allDoneItems, hasArchivedItems, showArchiveDialog, boards, showCreateBoardModal, showShareModal, showDeleteBoardModal, showMoveToBoardModal, boardItems, userBoardRole, accessibleBoards, switchBoard, theme, applyTheme, cycleTheme, columnSortModes, setColumnSortMode, columnAnnouncement } from '../../state/board-store';
+import { columns, showCreateModal, createModalInitialStatus, selectedItem, groupBy, rootItems, items, owners, labels as labelsStore, viewMode, setViewMode, allDoneItems, hasArchivedItems, showArchiveDialog, boards, showCreateBoardModal, showShareModal, showDeleteBoardModal, showMoveToBoardModal, boardItems, userBoardRole, accessibleBoards, switchBoard, theme, applyTheme, cycleTheme, columnSortModes, setColumnSortMode, columnAnnouncement } from '../../state/board-store';
 import type { SortMode } from '../../state/board-store';
 import { moveItem, reorderItem } from '../../state/actions';
 import { useKeyboardShortcuts } from '../../hooks/use-keyboard-shortcuts';
@@ -166,6 +166,11 @@ export function KanbanBoard() {
     }
   };
 
+  const handleAddItemToColumn = useCallback((status: ItemStatus) => {
+    createModalInitialStatus.value = status;
+    showCreateModal.value = true;
+  }, []);
+
   // Check if the current board is empty (zero items for this board, ignoring filters)
   const isBoardEmpty = boardItems.value.length === 0;
 
@@ -185,6 +190,7 @@ export function KanbanBoard() {
               onMoveStatus={handleMoveStatus}
               sortMode={columnSortModes.value[status]}
               onSortChange={(mode: SortMode) => setColumnSortMode(status, mode)}
+              onAddItem={() => handleAddItemToColumn(status)}
               {...(status === 'Done' ? {
                 allDoneCount: allDoneItems.value.length,
                 hasArchived: hasArchivedItems.value,

--- a/frontend/src/components/forms/create-item-modal.test.tsx
+++ b/frontend/src/components/forms/create-item-modal.test.tsx
@@ -17,6 +17,7 @@ vi.mock('../../auth/auth-context', () => ({
 const { mockBoardStore } = vi.hoisted(() => {
   const mockBoardStore = {
     showCreateModal: { value: true },
+    createModalInitialStatus: { value: null as string | null },
     owners: { value: [{ name: 'Test User', google_account: 'test@example.com' }, { name: 'Mom', google_account: 'mom@test.com' }, { name: 'Dad', google_account: 'dad@test.com' }] },
     labels: { value: [{ label: 'Urgent', color: '#ff0000' }] },
     openDetailWithTitleEdit: { value: false },
@@ -44,6 +45,7 @@ beforeEach(() => {
   mockCreateItem.mockClear();
   mockCreateItemWithSubtasks.mockClear();
   mockBoardStore.showCreateModal.value = true;
+  mockBoardStore.createModalInitialStatus.value = null;
 });
 
 // --- Inline Sub-tasks (Issue #55) ---
@@ -455,5 +457,93 @@ describe('CreateItemModal — Auto-assign default owner (Issue #112)', () => {
 
       mockBoardStore.owners.value = original;
     });
+  });
+});
+
+// --- Inline Add Item to Column (Issue #170) ---
+describe('CreateItemModal — Inline Add Item (Issue #170)', () => {
+  beforeEach(() => {
+    mockCreateItem.mockClear();
+    mockCreateItemWithSubtasks.mockClear();
+    mockBoardStore.showCreateModal.value = true;
+    mockBoardStore.createModalInitialStatus.value = null;
+  });
+
+  // AC1: Pre-filled status is passed to createItem
+  it('passes pre-filled status to createItem when createModalInitialStatus is set', () => {
+    mockBoardStore.createModalInitialStatus.value = 'In Progress';
+
+    const { container } = render(<CreateItemModal />);
+    const titleInput = container.querySelector('#title') as HTMLInputElement;
+    fireEvent.input(titleInput, { target: { value: 'New task' } });
+
+    // Set an owner (required for In Progress)
+    const ownerSelect = container.querySelector('#owner') as HTMLSelectElement;
+    fireEvent.change(ownerSelect, { target: { value: 'Mom' } });
+
+    const form = container.querySelector('form') as HTMLFormElement;
+    fireEvent.submit(form);
+
+    expect(mockCreateItem).toHaveBeenCalledTimes(1);
+    expect(mockCreateItem.mock.calls[0][0].status).toBe('In Progress');
+  });
+
+  // AC1: No status property when createModalInitialStatus is null (defaults to To Do)
+  it('does not set status when createModalInitialStatus is null', () => {
+    mockBoardStore.createModalInitialStatus.value = null;
+
+    const { container } = render(<CreateItemModal />);
+    const titleInput = container.querySelector('#title') as HTMLInputElement;
+    fireEvent.input(titleInput, { target: { value: 'New task' } });
+    const form = container.querySelector('form') as HTMLFormElement;
+    fireEvent.submit(form);
+
+    expect(mockCreateItem).toHaveBeenCalledTimes(1);
+    expect(mockCreateItem.mock.calls[0][0]).not.toHaveProperty('status');
+  });
+
+  // AC3: Pre-filled status works for Done column
+  it('passes Done status when createModalInitialStatus is Done', () => {
+    mockBoardStore.createModalInitialStatus.value = 'Done';
+
+    const { container } = render(<CreateItemModal />);
+    const titleInput = container.querySelector('#title') as HTMLInputElement;
+    fireEvent.input(titleInput, { target: { value: 'Completed task' } });
+    const form = container.querySelector('form') as HTMLFormElement;
+    fireEvent.submit(form);
+
+    expect(mockCreateItem).toHaveBeenCalledTimes(1);
+    expect(mockCreateItem.mock.calls[0][0].status).toBe('Done');
+  });
+
+  // Closing modal clears createModalInitialStatus
+  it('clears createModalInitialStatus when modal is closed', () => {
+    mockBoardStore.createModalInitialStatus.value = 'In Progress';
+
+    const { container } = render(<CreateItemModal />);
+    const closeBtn = container.querySelector('.modal-header .btn.btn-ghost') as HTMLButtonElement;
+    fireEvent.click(closeBtn);
+
+    expect(mockBoardStore.createModalInitialStatus.value).toBeNull();
+  });
+
+  // Pre-filled status works with subtasks
+  it('passes pre-filled status to createItemWithSubtasks', () => {
+    mockBoardStore.createModalInitialStatus.value = 'To Do';
+
+    const { container } = render(<CreateItemModal />);
+    const titleInput = container.querySelector('#title') as HTMLInputElement;
+    fireEvent.input(titleInput, { target: { value: 'Parent task' } });
+
+    // Add subtask
+    const subtaskInput = container.querySelector('#subtask-title') as HTMLInputElement;
+    fireEvent.input(subtaskInput, { target: { value: 'Child task' } });
+    fireEvent.keyDown(subtaskInput, { key: 'Enter' });
+
+    const form = container.querySelector('form') as HTMLFormElement;
+    fireEvent.submit(form);
+
+    expect(mockCreateItemWithSubtasks).toHaveBeenCalledTimes(1);
+    expect(mockCreateItemWithSubtasks.mock.calls[0][0].status).toBe('To Do');
   });
 });

--- a/frontend/src/components/forms/create-item-modal.tsx
+++ b/frontend/src/components/forms/create-item-modal.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useCallback, useMemo } from 'preact/hooks';
 import { useAuth } from '../../auth/auth-context';
-import { showCreateModal, owners, labels as labelsStore } from '../../state/board-store';
+import { showCreateModal, createModalInitialStatus, owners, labels as labelsStore } from '../../state/board-store';
 import { createItem, createItemWithSubtasks } from '../../state/actions';
 import type { StagedSubtask } from '../../state/actions';
 import { LabelPickerManager } from '../labels/label-picker-manager';
@@ -23,7 +23,10 @@ export function CreateItemModal() {
   const [subtaskInput, setSubtaskInput] = useState('');
   const subtaskInputRef = useRef<HTMLInputElement>(null);
 
-  const close = useCallback(() => { showCreateModal.value = false; }, []);
+  const close = useCallback(() => {
+    showCreateModal.value = false;
+    createModalInitialStatus.value = null;
+  }, []);
   const trapRef = useFocusTrap(close);
 
   const handleSubmit = (e: Event) => {
@@ -37,6 +40,7 @@ export function CreateItemModal() {
       due_date: dueDate,
       labels: selectedLabels.join(', '),
       created_by: user?.email || '',
+      ...(createModalInitialStatus.value ? { status: createModalInitialStatus.value } : {}),
     };
     const actor = user?.name || 'web';
 

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -867,6 +867,62 @@ body {
   border-radius: 10px;
 }
 
+/* Header "+" button — always visible in board view */
+.column-add-btn {
+  margin-left: auto;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: var(--radius-sm, 6px);
+  background: transparent;
+  color: var(--color-text-muted);
+  font-size: 18px;
+  font-weight: 600;
+  cursor: pointer;
+  line-height: 1;
+  padding: 0;
+}
+.column-add-btn:hover {
+  background: var(--overlay-hover);
+  color: var(--color-text);
+}
+.column-add-btn:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 1px;
+}
+
+/* Hover "Add item" row — appears on column hover, mouse-only */
+.column-add-row {
+  display: none;
+  width: 100%;
+  padding: 8px 12px;
+  margin-top: 4px;
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius-md, 8px);
+  background: transparent;
+  color: var(--color-text-muted);
+  font-size: 13px;
+  cursor: pointer;
+  text-align: left;
+  align-items: center;
+  gap: 4px;
+}
+.column:hover .column-add-row {
+  display: flex;
+}
+.column-add-row:hover {
+  background: var(--overlay-hover);
+  color: var(--color-text);
+  border-color: var(--color-text-muted);
+}
+.column-add-row-icon {
+  font-size: 15px;
+  font-weight: 600;
+}
+
 .column-cards {
   flex: 1;
   overflow-y: auto;

--- a/frontend/src/state/board-store.ts
+++ b/frontend/src/state/board-store.ts
@@ -71,6 +71,8 @@ export const selectedItemId = signal<string | null>(null);
 /** When true, CardDetail opens with the title EditableField in edit mode. */
 export const openDetailWithTitleEdit = signal(false);
 export const showCreateModal = signal(false);
+/** When set, the Create Item modal will pre-fill this status instead of defaulting to 'To Do'. */
+export const createModalInitialStatus = signal<ItemStatus | null>(null);
 export const toastMessage = signal<{ text: string; type: 'success' | 'error'; action?: { label: string; fn: () => void }; duration?: number } | null>(null);
 
 // --- View mode (mobile list vs board) ---


### PR DESCRIPTION
## Summary
Add two inline entry points to each kanban column for creating items directly in that column's status:
- Persistent "+" button in column headers (always visible, keyboard accessible with `aria-label`)
- Hover-activated "Add item" row at the bottom of each column (mouse-only, hidden during drag)

Closes #170

## Changes
- **`frontend/src/state/board-store.ts`** — Added `createModalInitialStatus` signal to communicate the target column status to the create modal
- **`frontend/src/components/forms/create-item-modal.tsx`** — Reads `createModalInitialStatus` on submit to pre-fill the status; clears signal on close
- **`frontend/src/components/board/column.tsx`** — Added `onAddItem` prop, "+" header button, and "Add item" hover row; hover row hidden during active drag and in compact mode
- **`frontend/src/components/board/kanban-board.tsx`** — Added `handleAddItemToColumn` handler; passes `onAddItem` to non-compact Column instances
- **`frontend/src/global.css`** — Styles for `.column-add-btn` (header button) and `.column-add-row` (hover row with CSS `:hover` visibility)

## Testing
- **AC1 (Header + button):** Tests verify aria-label, rendering, and click handler
- **AC2 (Hover row):** Tests verify rendering and content
- **AC3 (Hover row opens modal):** Tests verify click handler fires
- **AC4 (Drag unaffected):** Tests verify hover row hidden when `currentDragStatus` is set
- **AC5 (Board view only):** Tests verify neither element renders in compact mode
- **AC6 (In Progress owner):** Tests verify status pre-fill passes through to createItem (existing validation handles the rest)
- 14 new test cases across column.test.tsx and create-item-modal.test.tsx

## Rules Sync
- [x] No business rule changes needed — `createItem` already handles status, completed_at, and owner validation