### PR TITLE
feat: quick filter redesign — text search, due date, menu reorganization

### DIFF
--- a/frontend/src/components/board/view-toggle.test.tsx
+++ b/frontend/src/components/board/view-toggle.test.tsx
@@ -31,6 +31,8 @@ vi.mock('../../state/board-store', () => ({
   labels: { value: [] },
   filterOwner: { value: null },
   filterLabel: { value: null },
+  filterSearch: { value: '' },
+  filterDue: { value: null },
   loading: { value: false },
   getChildCount: () => ({ done: 0, total: 0 }),
   viewMode: mockViewMode,

--- a/frontend/src/components/header/control-bar.test.tsx
+++ b/frontend/src/components/header/control-bar.test.tsx
@@ -13,19 +13,21 @@ const { mockState, mockSwitchBoard, mockSetViewMode } = vi.hoisted(() => ({
     activeBoard: { name: 'Work', color: '#ff0000' } as any,
     userBoardRole: 'owner' as string | null,
     viewMode: 'board' as string,
-    filterOwner: null as string | null,
     filterLabel: null as string | null,
+    filterSearch: '',
+    filterDue: null as string | null,
     groupBy: 'none' as string,
-    owners: [
-      { name: 'Luke', google_account: 'luke@example.com' },
-      { name: 'Sarah', google_account: 'sarah@example.com' },
-    ],
     labels: [
       { label: 'Urgent', color: '#ff0000' },
       { label: 'Home', color: '#00cc00' },
     ],
     showCreateBoardModal: false,
     showShareModal: false,
+    rootItems: [
+      { id: '1', title: 'Task 1' },
+      { id: '2', title: 'Task 2' },
+      { id: '3', title: 'Task 3' },
+    ] as any[],
   },
   mockSwitchBoard: vi.fn(),
   mockSetViewMode: vi.fn(),
@@ -38,20 +40,24 @@ vi.mock('../../state/board-store', () => ({
   activeBoard: { get value() { return mockState.activeBoard; } },
   userBoardRole: { get value() { return mockState.userBoardRole; } },
   viewMode: { get value() { return mockState.viewMode; } },
-  filterOwner: {
-    get value() { return mockState.filterOwner; },
-    set value(v: string | null) { mockState.filterOwner = v; },
-  },
   filterLabel: {
     get value() { return mockState.filterLabel; },
     set value(v: string | null) { mockState.filterLabel = v; },
+  },
+  filterSearch: {
+    get value() { return mockState.filterSearch; },
+    set value(v: string) { mockState.filterSearch = v; },
+  },
+  filterDue: {
+    get value() { return mockState.filterDue; },
+    set value(v: string | null) { mockState.filterDue = v; },
   },
   groupBy: {
     get value() { return mockState.groupBy; },
     set value(v: string) { mockState.groupBy = v; },
   },
-  owners: { get value() { return mockState.owners; } },
   labels: { get value() { return mockState.labels; } },
+  rootItems: { get value() { return mockState.rootItems; } },
   switchBoard: (...args: any[]) => mockSwitchBoard(...args),
   setViewMode: (...args: any[]) => mockSetViewMode(...args),
   showCreateBoardModal: {
@@ -69,7 +75,6 @@ afterEach(() => {
   cleanup();
   mockSwitchBoard.mockClear();
   mockSetViewMode.mockClear();
-  // Reset to mobile default (JSDOM innerWidth = 0)
   Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 0 });
 });
 
@@ -83,12 +88,17 @@ beforeEach(() => {
   mockState.activeBoard = { name: 'Work', color: '#ff0000' };
   mockState.userBoardRole = 'owner';
   mockState.viewMode = 'board';
-  mockState.filterOwner = null;
   mockState.filterLabel = null;
+  mockState.filterSearch = '';
+  mockState.filterDue = null;
   mockState.groupBy = 'none';
   mockState.showCreateBoardModal = false;
   mockState.showShareModal = false;
-  // Default to mobile (JSDOM innerWidth = 0)
+  mockState.rootItems = [
+    { id: '1', title: 'Task 1' },
+    { id: '2', title: 'Task 2' },
+    { id: '3', title: 'Task 3' },
+  ];
   Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 0 });
 });
 
@@ -115,142 +125,225 @@ describe('ControlBar', () => {
     });
   });
 
-  describe('#163 — AC1: Board option labels no longer include shortcut text', () => {
-    const HINT = 'Ctrl+1–9 to switch boards · Press ? for all shortcuts';
-
-    it('option labels show name only — no (Ctrl+N) suffix on desktop', () => {
+  describe('#177 AC1: Text search input renders in filter bar', () => {
+    it('renders search input with placeholder', () => {
       Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1280 });
       const { container } = render(<ControlBar />);
-      const options = Array.from(container.querySelectorAll('[data-testid="control-bar-board-select"] option'));
-      const boardOptions = options.filter(o => (o as HTMLOptionElement).value !== '__new__');
-      boardOptions.forEach(opt => {
-        expect(opt.textContent).not.toMatch(/\(Ctrl\+\d\)/);
-      });
+      const input = container.querySelector('[data-testid="filter-search-input"]') as HTMLInputElement;
+      expect(input).not.toBeNull();
+      expect(input.placeholder).toBe('Search cards...');
     });
 
-    it('option with icon shows icon + name only', () => {
-      mockState.accessibleBoards = [
-        { id: 'b1', name: 'Work', icon: '💼' },
-        { id: 'b2', name: 'Family', icon: '' },
-      ];
+    it('search input has aria-label="Search cards"', () => {
       Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1280 });
       const { container } = render(<ControlBar />);
-      const b1Option = container.querySelector('[data-testid="control-bar-board-select"] option[value="b1"]');
-      expect(b1Option!.textContent).toBe('💼 Work');
-      expect(b1Option!.textContent).not.toContain('Ctrl');
+      const input = container.querySelector('[data-testid="filter-search-input"]');
+      expect(input!.getAttribute('aria-label')).toBe('Search cards');
     });
 
-    it('option without icon shows name only', () => {
+    it('search wrapper has flex: 1 for available space (via class)', () => {
       Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1280 });
       const { container } = render(<ControlBar />);
-      const b2Option = container.querySelector('[data-testid="control-bar-board-select"] option[value="b2"]');
-      expect(b2Option!.textContent).toBe('Family');
-    });
-
-    describe('#163 — AC2: Select shows shortcut hint via title', () => {
-      it('select element has correct title attribute', () => {
-        const { container } = render(<ControlBar />);
-        const select = container.querySelector('[data-testid="control-bar-board-select"]');
-        expect(select!.getAttribute('title')).toBe(HINT);
-      });
-    });
-
-    describe('#163 — AC4: Screen readers via aria-describedby', () => {
-      it('select has aria-describedby pointing to board-switcher-hint', () => {
-        const { container } = render(<ControlBar />);
-        const select = container.querySelector('[data-testid="control-bar-board-select"]');
-        expect(select!.getAttribute('aria-describedby')).toBe('board-switcher-hint');
-      });
-
-      it('sr-only span #board-switcher-hint exists with hint text', () => {
-        const { container } = render(<ControlBar />);
-        const hint = container.querySelector('#board-switcher-hint');
-        expect(hint).not.toBeNull();
-        expect(hint!.classList.contains('sr-only')).toBe(true);
-        expect(hint!.textContent).toBe(HINT);
-      });
-
-      it('hint text references Ctrl+1 and ? shortcuts', () => {
-        const { container } = render(<ControlBar />);
-        const hint = container.querySelector('#board-switcher-hint');
-        expect(hint!.textContent).toContain('Ctrl+1');
-        expect(hint!.textContent).toContain('?');
-      });
+      const wrapper = container.querySelector('[data-testid="filter-search-wrapper"]');
+      expect(wrapper).not.toBeNull();
+      expect(wrapper!.classList.contains('filter-search-wrapper')).toBe(true);
     });
   });
 
-  describe('CSS separators', () => {
-    it('renders one separator span with aria-hidden', () => {
+  describe('#177 AC2: Text search filters cards in real time', () => {
+    it('shows × clear button when search has text', () => {
       const { container } = render(<ControlBar />);
-      const separators = container.querySelectorAll('.control-bar-separator');
-      expect(separators.length).toBe(1);
-      separators.forEach(sep => {
-        expect(sep.getAttribute('aria-hidden')).toBe('true');
-      });
+      const input = container.querySelector('[data-testid="filter-search-input"]') as HTMLInputElement;
+      fireEvent.input(input, { target: { value: 'test' } });
+      const clearBtn = container.querySelector('[data-testid="filter-search-clear"]');
+      expect(clearBtn).not.toBeNull();
+    });
+
+    it('hides × clear button when search is empty', () => {
+      const { container } = render(<ControlBar />);
+      const clearBtn = container.querySelector('[data-testid="filter-search-clear"]');
+      expect(clearBtn).toBeNull();
+    });
+
+    it('clicking × clears the search', () => {
+      const { container } = render(<ControlBar />);
+      const input = container.querySelector('[data-testid="filter-search-input"]') as HTMLInputElement;
+      fireEvent.input(input, { target: { value: 'test' } });
+      const clearBtn = container.querySelector('[data-testid="filter-search-clear"]') as HTMLElement;
+      fireEvent.click(clearBtn);
+      expect(input.value).toBe('');
+      expect(mockState.filterSearch).toBe('');
+    });
+
+    it('updates filterSearch signal after debounce', async () => {
+      vi.useFakeTimers();
+      const { container } = render(<ControlBar />);
+      const input = container.querySelector('[data-testid="filter-search-input"]') as HTMLInputElement;
+      fireEvent.input(input, { target: { value: 'kanban' } });
+      // Before debounce, signal not yet updated
+      expect(mockState.filterSearch).toBe('');
+      vi.advanceTimersByTime(150);
+      expect(mockState.filterSearch).toBe('kanban');
+      vi.useRealTimers();
     });
   });
 
-  describe('AC2: Desktop — no Filters toggle button visible', () => {
-    it('filter toggle is rendered but hidden via CSS on desktop (not in DOM logic)', () => {
-      // On desktop (innerWidth > 768), isMobile=false so filter toggle is rendered
-      // but CSS hides it. In JS/JSDOM we can verify the element exists and filter content is visible.
-      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1024 });
-      const { container } = render(<ControlBar />);
-      // Filter content should NOT have the collapsed class on desktop
-      const content = container.querySelector('[data-testid="control-bar-filter-content"]');
-      expect(content!.className).not.toContain('control-bar-filter-content-collapsed');
-    });
-  });
-
-  describe('AC1: Desktop — filter chips always visible', () => {
-    it('filter content has no collapsed class on desktop', () => {
+  describe('#177 AC4: Due quick-filter — Today', () => {
+    it('renders Today chip in due filter group', () => {
       Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1280 });
       const { container } = render(<ControlBar />);
-      const content = container.querySelector('[data-testid="control-bar-filter-content"]');
-      expect(content!.className).not.toContain('control-bar-filter-content-collapsed');
+      const chip = container.querySelector('[data-testid="filter-due-today"]');
+      expect(chip).not.toBeNull();
+      expect(chip!.textContent).toBe('Today');
     });
 
-    it('owner chips are rendered without needing to click filter toggle on desktop', () => {
+    it('clicking Today sets filterDue to "today"', () => {
+      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1280 });
+      const { container } = render(<ControlBar />);
+      fireEvent.click(container.querySelector('[data-testid="filter-due-today"]') as HTMLElement);
+      expect(mockState.filterDue).toBe('today');
+    });
+
+    it('clicking Today again clears the filter', () => {
+      mockState.filterDue = 'today';
+      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1280 });
+      const { container } = render(<ControlBar />);
+      fireEvent.click(container.querySelector('[data-testid="filter-due-today"]') as HTMLElement);
+      expect(mockState.filterDue).toBeNull();
+    });
+
+    it('active Today chip has filter-chip-active class and aria-pressed="true"', () => {
+      mockState.filterDue = 'today';
+      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1280 });
+      const { container } = render(<ControlBar />);
+      const chip = container.querySelector('[data-testid="filter-due-today"]');
+      expect(chip!.classList.contains('filter-chip-active')).toBe(true);
+      expect(chip!.getAttribute('aria-pressed')).toBe('true');
+    });
+  });
+
+  describe('#177 AC5: Due quick-filter — This Week', () => {
+    it('renders This Week chip', () => {
+      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1280 });
+      const { container } = render(<ControlBar />);
+      const chip = container.querySelector('[data-testid="filter-due-this-week"]');
+      expect(chip).not.toBeNull();
+      expect(chip!.textContent).toBe('This Week');
+    });
+
+    it('clicking This Week sets filterDue to "this-week"', () => {
+      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1280 });
+      const { container } = render(<ControlBar />);
+      fireEvent.click(container.querySelector('[data-testid="filter-due-this-week"]') as HTMLElement);
+      expect(mockState.filterDue).toBe('this-week');
+    });
+
+    it('due chips are mutually exclusive', () => {
+      mockState.filterDue = 'today';
+      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1280 });
+      const { container } = render(<ControlBar />);
+      fireEvent.click(container.querySelector('[data-testid="filter-due-this-week"]') as HTMLElement);
+      expect(mockState.filterDue).toBe('this-week');
+    });
+  });
+
+  describe('#177 AC7: Owner chip group removed', () => {
+    it('no "Filter by owner" group exists', () => {
       Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1280 });
       const { container } = render(<ControlBar />);
       const ownerGroup = container.querySelector('[aria-label="Filter by owner"]');
-      expect(ownerGroup).not.toBeNull();
-      const chips = ownerGroup!.querySelectorAll('button.filter-chip');
-      expect(chips.length).toBe(2);
+      expect(ownerGroup).toBeNull();
     });
 
-    it('group labels are visible on desktop', () => {
+    it('no "Owner:" label text exists', () => {
       Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1280 });
       const { container } = render(<ControlBar />);
-      const labels = container.querySelectorAll('.filter-chip-group-label');
-      expect(labels.length).toBeGreaterThanOrEqual(3); // Owner:, Label:, Group:
+      const labels = Array.from(container.querySelectorAll('.filter-chip-group-label'));
+      const ownerLabel = labels.find(l => l.textContent === 'Owner:');
+      expect(ownerLabel).toBeUndefined();
     });
   });
 
-  describe('AC3: Mobile — filter controls behind Filters button', () => {
-    it('renders filter toggle button on mobile', () => {
-      // JSDOM defaults to innerWidth=0 (mobile)
+  describe('#177 AC8: Grouping moved to 3-dot menu', () => {
+    it('no "Group by" chip group in filter bar', () => {
+      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1280 });
       const { container } = render(<ControlBar />);
-      const toggle = container.querySelector('[data-testid="control-bar-filter-toggle"]');
-      expect(toggle).not.toBeNull();
-      expect(toggle!.textContent).toBe('Filters');
+      const groupSection = container.querySelector('[aria-label="Group by"]');
+      expect(groupSection).toBeNull();
     });
 
-    it('filter content has collapsed class on mobile by default', () => {
+    it('3-dot menu has Views section header', () => {
+      const { container } = render(<ControlBar />);
+      fireEvent.click(container.querySelector('[data-testid="overflow-menu-btn"]') as HTMLElement);
+      const headers = Array.from(container.querySelectorAll('.overflow-menu-section-header'));
+      expect(headers.some(h => h.textContent === 'Views')).toBe(true);
+    });
+
+    it('3-dot menu has Grouping section header', () => {
+      const { container } = render(<ControlBar />);
+      fireEvent.click(container.querySelector('[data-testid="overflow-menu-btn"]') as HTMLElement);
+      const headers = Array.from(container.querySelectorAll('.overflow-menu-section-header'));
+      expect(headers.some(h => h.textContent === 'Grouping')).toBe(true);
+    });
+
+    it('3-dot menu has Settings section header for owners', () => {
+      mockState.userBoardRole = 'owner';
+      const { container } = render(<ControlBar />);
+      fireEvent.click(container.querySelector('[data-testid="overflow-menu-btn"]') as HTMLElement);
+      const headers = Array.from(container.querySelectorAll('.overflow-menu-section-header'));
+      expect(headers.some(h => h.textContent === 'Settings')).toBe(true);
+    });
+
+    it('3-dot menu has hr dividers between sections', () => {
+      const { container } = render(<ControlBar />);
+      fireEvent.click(container.querySelector('[data-testid="overflow-menu-btn"]') as HTMLElement);
+      const dividers = container.querySelectorAll('.overflow-menu-divider');
+      expect(dividers.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('grouping items use role="menuitemradio"', () => {
+      const { container } = render(<ControlBar />);
+      fireEvent.click(container.querySelector('[data-testid="overflow-menu-btn"]') as HTMLElement);
+      const noneItem = container.querySelector('[data-testid="overflow-menu-group-none"]');
+      const labelItem = container.querySelector('[data-testid="overflow-menu-group-label"]');
+      expect(noneItem!.getAttribute('role')).toBe('menuitemradio');
+      expect(labelItem!.getAttribute('role')).toBe('menuitemradio');
+    });
+
+    it('"None" grouping has aria-checked="true" by default', () => {
+      const { container } = render(<ControlBar />);
+      fireEvent.click(container.querySelector('[data-testid="overflow-menu-btn"]') as HTMLElement);
+      const noneItem = container.querySelector('[data-testid="overflow-menu-group-none"]');
+      expect(noneItem!.getAttribute('aria-checked')).toBe('true');
+    });
+
+    it('clicking "By Label" sets groupBy to "label" and closes menu', () => {
+      const { container } = render(<ControlBar />);
+      fireEvent.click(container.querySelector('[data-testid="overflow-menu-btn"]') as HTMLElement);
+      fireEvent.click(container.querySelector('[data-testid="overflow-menu-group-label"]') as HTMLElement);
+      expect(mockState.groupBy).toBe('label');
+      expect(container.querySelector('[data-testid="overflow-menu-dropdown"]')).toBeNull();
+    });
+  });
+
+  describe('#177 AC9: Mobile responsive', () => {
+    it('filter content collapsed on mobile by default', () => {
       const { container } = render(<ControlBar />);
       const content = container.querySelector('[data-testid="control-bar-filter-content"]');
       expect(content!.className).toContain('control-bar-filter-content-collapsed');
     });
 
-    it('shows filter badge when filters active on mobile', () => {
-      mockState.filterOwner = 'Luke';
+    it('Filters toggle shows badge with active filter count (search + due + label)', () => {
+      mockState.filterSearch = 'test';
+      mockState.filterDue = 'today';
+      mockState.filterLabel = 'Urgent';
       const { container } = render(<ControlBar />);
       const badge = container.querySelector('.filter-badge');
       expect(badge).not.toBeNull();
-      expect(badge!.textContent).toBe('1');
+      expect(badge!.textContent).toBe('3');
     });
 
-    it('clicking toggle expands filter content on mobile', () => {
+    it('clicking toggle expands filters on mobile', () => {
       const { container } = render(<ControlBar />);
       const toggle = container.querySelector('[data-testid="control-bar-filter-toggle"]') as HTMLElement;
       fireEvent.click(toggle);
@@ -258,212 +351,44 @@ describe('ControlBar', () => {
       const content = container.querySelector('[data-testid="control-bar-filter-content"]');
       expect(content!.className).not.toContain('control-bar-filter-content-collapsed');
     });
-  });
 
-  describe('Filter chips', () => {
-    it('renders owner chips', () => {
+    it('badge count does not include owner (removed)', () => {
+      // Only search + due + label count
+      mockState.filterSearch = 'test';
       const { container } = render(<ControlBar />);
-      fireEvent.click(container.querySelector('[data-testid="control-bar-filter-toggle"]') as HTMLElement);
-      const ownerGroup = container.querySelector('[aria-label="Filter by owner"]');
-      const chips = ownerGroup!.querySelectorAll('button.filter-chip');
-      expect(chips.length).toBe(2);
-    });
-
-    it('clicking owner chip activates filter', () => {
-      const { container } = render(<ControlBar />);
-      fireEvent.click(container.querySelector('[data-testid="control-bar-filter-toggle"]') as HTMLElement);
-      const ownerGroup = container.querySelector('[aria-label="Filter by owner"]')!;
-      const lukeChip = ownerGroup.querySelectorAll('button.filter-chip')[0] as HTMLElement;
-      fireEvent.click(lukeChip);
-      expect(mockState.filterOwner).toBe('Luke');
+      const badge = container.querySelector('.filter-badge');
+      expect(badge!.textContent).toBe('1');
     });
   });
 
-  describe('Reset all button', () => {
-    it('shows Reset all when filters active', () => {
-      mockState.filterOwner = 'Luke';
+  describe('#177 AC10: Search input accessibility', () => {
+    it('live region shows filtered count when filters active', () => {
+      mockState.filterSearch = 'test';
+      mockState.rootItems = [{ id: '1', title: 'Task 1' }, { id: '2', title: 'Task 2' }];
       const { container } = render(<ControlBar />);
-      fireEvent.click(container.querySelector('[data-testid="control-bar-filter-toggle"]') as HTMLElement);
-      const reset = container.querySelector('[data-testid="control-bar-reset"]');
-      expect(reset).not.toBeNull();
-      expect(reset!.textContent).toBe('Reset all');
+      const liveRegion = container.querySelector('[data-testid="filter-live-region"]');
+      expect(liveRegion).not.toBeNull();
+      expect(liveRegion!.getAttribute('aria-live')).toBe('polite');
+      expect(liveRegion!.textContent).toBe('2 cards shown');
     });
 
-    it('Reset all clears all filters and grouping', () => {
-      mockState.filterOwner = 'Luke';
-      mockState.filterLabel = 'Urgent';
-      mockState.groupBy = 'owner';
+    it('live region is empty when no filters active', () => {
       const { container } = render(<ControlBar />);
-      fireEvent.click(container.querySelector('[data-testid="control-bar-filter-toggle"]') as HTMLElement);
-      fireEvent.click(container.querySelector('[data-testid="control-bar-reset"]') as HTMLElement);
-      expect(mockState.filterOwner).toBeNull();
-      expect(mockState.filterLabel).toBeNull();
-      expect(mockState.groupBy).toBe('none');
+      const liveRegion = container.querySelector('[data-testid="filter-live-region"]');
+      expect(liveRegion!.textContent).toBe('');
     });
 
-    it('hidden when no filters active', () => {
+    it('pressing Escape in search input clears it', () => {
       const { container } = render(<ControlBar />);
-      fireEvent.click(container.querySelector('[data-testid="control-bar-filter-toggle"]') as HTMLElement);
-      const reset = container.querySelector('[data-testid="control-bar-reset"]');
-      expect(reset).toBeNull();
+      const input = container.querySelector('[data-testid="filter-search-input"]') as HTMLInputElement;
+      fireEvent.input(input, { target: { value: 'test' } });
+      fireEvent.keyDown(input, { key: 'Escape' });
+      expect(input.value).toBe('');
     });
   });
 
-  describe('AC10: Active filter chips inline', () => {
-    it('shows active chips when owner filter set', () => {
-      mockState.filterOwner = 'Luke';
-      const { container } = render(<ControlBar />);
-      const chips = container.querySelectorAll('[data-testid="control-bar-chip"]');
-      expect(chips.length).toBe(1);
-      expect(chips[0].textContent).toContain('Owner: Luke');
-    });
-
-    it('shows remove button on chip', () => {
-      mockState.filterOwner = 'Luke';
-      const { container } = render(<ControlBar />);
-      const removeBtn = container.querySelector('.control-bar-chip-remove');
-      expect(removeBtn).not.toBeNull();
-      expect(removeBtn!.getAttribute('aria-label')).toBe('Remove Owner: Luke filter');
-    });
-
-    it('clicking remove clears the filter', () => {
-      mockState.filterOwner = 'Luke';
-      const { container } = render(<ControlBar />);
-      fireEvent.click(container.querySelector('.control-bar-chip-remove') as HTMLElement);
-      expect(mockState.filterOwner).toBeNull();
-    });
-  });
-
-  describe('AC4: 3-dot overflow menu — structure and ARIA', () => {
-    it('renders the overflow ⋯ button', () => {
-      const { container } = render(<ControlBar />);
-      const btn = container.querySelector('[data-testid="overflow-menu-btn"]');
-      expect(btn).not.toBeNull();
-    });
-
-    it('⋯ button has aria-label="More options"', () => {
-      const { container } = render(<ControlBar />);
-      const btn = container.querySelector('[data-testid="overflow-menu-btn"]');
-      expect(btn!.getAttribute('aria-label')).toBe('More options');
-    });
-
-    it('⋯ button has aria-haspopup="true"', () => {
-      const { container } = render(<ControlBar />);
-      const btn = container.querySelector('[data-testid="overflow-menu-btn"]');
-      expect(btn!.getAttribute('aria-haspopup')).toBe('true');
-    });
-
-    it('⋯ button has aria-expanded="false" when closed', () => {
-      const { container } = render(<ControlBar />);
-      const btn = container.querySelector('[data-testid="overflow-menu-btn"]');
-      expect(btn!.getAttribute('aria-expanded')).toBe('false');
-    });
-
-    it('⋯ button has aria-expanded="true" when open', () => {
-      const { container } = render(<ControlBar />);
-      const btn = container.querySelector('[data-testid="overflow-menu-btn"]') as HTMLElement;
-      fireEvent.click(btn);
-      expect(btn.getAttribute('aria-expanded')).toBe('true');
-    });
-
-    it('clicking ⋯ opens dropdown with role="menu"', () => {
-      const { container } = render(<ControlBar />);
-      fireEvent.click(container.querySelector('[data-testid="overflow-menu-btn"]') as HTMLElement);
-      const menu = container.querySelector('[data-testid="overflow-menu-dropdown"]');
-      expect(menu).not.toBeNull();
-      expect(menu!.getAttribute('role')).toBe('menu');
-    });
-
-    it('menu items have role="menuitem"', () => {
-      const { container } = render(<ControlBar />);
-      fireEvent.click(container.querySelector('[data-testid="overflow-menu-btn"]') as HTMLElement);
-      const items = container.querySelectorAll('[role="menuitem"]');
-      expect(items.length).toBeGreaterThanOrEqual(2);
-      items.forEach(item => expect(item.getAttribute('role')).toBe('menuitem'));
-    });
-
-    it('Board view item has aria-checked="true" when in board mode', () => {
-      mockState.viewMode = 'board';
-      const { container } = render(<ControlBar />);
-      fireEvent.click(container.querySelector('[data-testid="overflow-menu-btn"]') as HTMLElement);
-      const boardItem = container.querySelector('[data-testid="overflow-menu-view-board"]');
-      expect(boardItem!.getAttribute('aria-checked')).toBe('true');
-    });
-
-    it('List view item has aria-checked="true" when in list mode', () => {
-      mockState.viewMode = 'list';
-      const { container } = render(<ControlBar />);
-      fireEvent.click(container.querySelector('[data-testid="overflow-menu-btn"]') as HTMLElement);
-      const listItem = container.querySelector('[data-testid="overflow-menu-view-list"]');
-      expect(listItem!.getAttribute('aria-checked')).toBe('true');
-    });
-  });
-
-  describe('AC5: View toggle in 3-dot switches view and closes menu', () => {
-    it('clicking Board view in menu calls setViewMode("board")', () => {
-      const { container } = render(<ControlBar />);
-      fireEvent.click(container.querySelector('[data-testid="overflow-menu-btn"]') as HTMLElement);
-      fireEvent.click(container.querySelector('[data-testid="overflow-menu-view-board"]') as HTMLElement);
-      expect(mockSetViewMode).toHaveBeenCalledWith('board');
-    });
-
-    it('clicking List view in menu calls setViewMode("list")', () => {
-      const { container } = render(<ControlBar />);
-      fireEvent.click(container.querySelector('[data-testid="overflow-menu-btn"]') as HTMLElement);
-      fireEvent.click(container.querySelector('[data-testid="overflow-menu-view-list"]') as HTMLElement);
-      expect(mockSetViewMode).toHaveBeenCalledWith('list');
-    });
-
-    it('menu closes after selecting view', () => {
-      const { container } = render(<ControlBar />);
-      fireEvent.click(container.querySelector('[data-testid="overflow-menu-btn"]') as HTMLElement);
-      fireEvent.click(container.querySelector('[data-testid="overflow-menu-view-list"]') as HTMLElement);
-      const menu = container.querySelector('[data-testid="overflow-menu-dropdown"]');
-      expect(menu).toBeNull();
-    });
-  });
-
-  describe('AC6: Board Settings item opens the settings modal', () => {
-    it('Board Settings item appears for owner in 3-dot menu', () => {
-      mockState.userBoardRole = 'owner';
-      const { container } = render(<ControlBar />);
-      fireEvent.click(container.querySelector('[data-testid="overflow-menu-btn"]') as HTMLElement);
-      const settings = container.querySelector('[data-testid="overflow-menu-board-settings"]');
-      expect(settings).not.toBeNull();
-      expect(settings!.textContent).toBe('Board Settings');
-    });
-
-    it('clicking Board Settings sets showShareModal=true and closes menu', () => {
-      mockState.userBoardRole = 'owner';
-      const { container } = render(<ControlBar />);
-      fireEvent.click(container.querySelector('[data-testid="overflow-menu-btn"]') as HTMLElement);
-      fireEvent.click(container.querySelector('[data-testid="overflow-menu-board-settings"]') as HTMLElement);
-      expect(mockState.showShareModal).toBe(true);
-      const menu = container.querySelector('[data-testid="overflow-menu-dropdown"]');
-      expect(menu).toBeNull();
-    });
-  });
-
-  describe('AC7: Non-owners do not see Board Settings', () => {
-    it('Board Settings item is absent for non-owner', () => {
-      mockState.userBoardRole = 'member';
-      const { container } = render(<ControlBar />);
-      fireEvent.click(container.querySelector('[data-testid="overflow-menu-btn"]') as HTMLElement);
-      const settings = container.querySelector('[data-testid="overflow-menu-board-settings"]');
-      expect(settings).toBeNull();
-    });
-
-    it('only view toggle items present for non-owner', () => {
-      mockState.userBoardRole = 'member';
-      const { container } = render(<ControlBar />);
-      fireEvent.click(container.querySelector('[data-testid="overflow-menu-btn"]') as HTMLElement);
-      const items = container.querySelectorAll('[role="menuitem"]');
-      expect(items.length).toBe(2);
-    });
-  });
-
-  describe('AC8: 3-dot menu — keyboard navigation', () => {
-    it('Escape closes the menu and no error is thrown', () => {
+  describe('3-dot menu — keyboard navigation (preserved)', () => {
+    it('Escape closes the menu', () => {
       const { container } = render(<ControlBar />);
       fireEvent.click(container.querySelector('[data-testid="overflow-menu-btn"]') as HTMLElement);
       expect(container.querySelector('[data-testid="overflow-menu-dropdown"]')).not.toBeNull();
@@ -473,31 +398,7 @@ describe('ControlBar', () => {
       expect(container.querySelector('[data-testid="overflow-menu-dropdown"]')).toBeNull();
     });
 
-    it('ArrowDown moves focus between menu items', () => {
-      const { container } = render(<ControlBar />);
-      fireEvent.click(container.querySelector('[data-testid="overflow-menu-btn"]') as HTMLElement);
-      const items = container.querySelectorAll<HTMLElement>('[role="menuitem"]');
-      items[0].focus();
-      act(() => {
-        fireEvent.keyDown(document, { key: 'ArrowDown' });
-      });
-      expect(document.activeElement).toBe(items[1]);
-    });
-
-    it('ArrowUp moves focus between menu items', () => {
-      const { container } = render(<ControlBar />);
-      fireEvent.click(container.querySelector('[data-testid="overflow-menu-btn"]') as HTMLElement);
-      const items = container.querySelectorAll<HTMLElement>('[role="menuitem"]');
-      items[1].focus();
-      act(() => {
-        fireEvent.keyDown(document, { key: 'ArrowUp' });
-      });
-      expect(document.activeElement).toBe(items[0]);
-    });
-  });
-
-  describe('AC9: 3-dot menu — click-outside to dismiss', () => {
-    it('clicking outside the menu closes it', () => {
+    it('click-outside closes menu', () => {
       const { container } = render(<ControlBar />);
       fireEvent.click(container.querySelector('[data-testid="overflow-menu-btn"]') as HTMLElement);
       expect(container.querySelector('[data-testid="overflow-menu-dropdown"]')).not.toBeNull();
@@ -505,6 +406,70 @@ describe('ControlBar', () => {
         fireEvent.mouseDown(document.body);
       });
       expect(container.querySelector('[data-testid="overflow-menu-dropdown"]')).toBeNull();
+    });
+  });
+
+  describe('View toggle (preserved)', () => {
+    it('clicking Board view calls setViewMode("board")', () => {
+      const { container } = render(<ControlBar />);
+      fireEvent.click(container.querySelector('[data-testid="overflow-menu-btn"]') as HTMLElement);
+      fireEvent.click(container.querySelector('[data-testid="overflow-menu-view-board"]') as HTMLElement);
+      expect(mockSetViewMode).toHaveBeenCalledWith('board');
+    });
+
+    it('clicking List view calls setViewMode("list")', () => {
+      const { container } = render(<ControlBar />);
+      fireEvent.click(container.querySelector('[data-testid="overflow-menu-btn"]') as HTMLElement);
+      fireEvent.click(container.querySelector('[data-testid="overflow-menu-view-list"]') as HTMLElement);
+      expect(mockSetViewMode).toHaveBeenCalledWith('list');
+    });
+  });
+
+  describe('Board Settings (preserved)', () => {
+    it('appears for owner', () => {
+      mockState.userBoardRole = 'owner';
+      const { container } = render(<ControlBar />);
+      fireEvent.click(container.querySelector('[data-testid="overflow-menu-btn"]') as HTMLElement);
+      expect(container.querySelector('[data-testid="overflow-menu-board-settings"]')).not.toBeNull();
+    });
+
+    it('hidden for non-owner', () => {
+      mockState.userBoardRole = 'member';
+      const { container } = render(<ControlBar />);
+      fireEvent.click(container.querySelector('[data-testid="overflow-menu-btn"]') as HTMLElement);
+      expect(container.querySelector('[data-testid="overflow-menu-board-settings"]')).toBeNull();
+    });
+  });
+
+  describe('Board switcher hints (preserved)', () => {
+    it('select has correct title attribute', () => {
+      const { container } = render(<ControlBar />);
+      const select = container.querySelector('[data-testid="control-bar-board-select"]');
+      expect(select!.getAttribute('title')).toContain('Ctrl+1');
+    });
+
+    it('sr-only hint exists', () => {
+      const { container } = render(<ControlBar />);
+      const hint = container.querySelector('#board-switcher-hint');
+      expect(hint).not.toBeNull();
+      expect(hint!.classList.contains('sr-only')).toBe(true);
+    });
+  });
+
+  describe('Due filter group a11y', () => {
+    it('due filter group has role="group" and aria-label', () => {
+      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1280 });
+      const { container } = render(<ControlBar />);
+      const group = container.querySelector('[data-testid="filter-due-group"]');
+      expect(group!.getAttribute('role')).toBe('group');
+      expect(group!.getAttribute('aria-label')).toBe('Filter by due date');
+    });
+
+    it('due chips have aria-pressed', () => {
+      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1280 });
+      const { container } = render(<ControlBar />);
+      const todayChip = container.querySelector('[data-testid="filter-due-today"]');
+      expect(todayChip!.getAttribute('aria-pressed')).toBe('false');
     });
   });
 });

--- a/frontend/src/components/header/control-bar.tsx
+++ b/frontend/src/components/header/control-bar.tsx
@@ -1,29 +1,29 @@
-import { useState, useEffect, useRef } from 'preact/hooks';
+import { useState, useEffect, useRef, useCallback } from 'preact/hooks';
 import {
   boards, activeBoardId, switchBoard, showCreateBoardModal, showShareModal,
   accessibleBoards, activeBoard, userBoardRole,
   viewMode, setViewMode,
-  filterOwner, filterLabel, groupBy, owners, labels as labelsStore,
+  filterLabel, filterSearch, filterDue, groupBy,
+  labels as labelsStore, rootItems,
 } from '../../state/board-store';
+import type { DueFilter } from '../../state/board-store';
 
 /**
- * AC1/AC2: Desktop — filter chips always visible inline, no Filters toggle.
- * AC3: Mobile — Filters toggle button, chips hidden until tapped.
- * AC4–AC9: 3-dot overflow menu with view toggle + Board Settings (owner only).
- * AC10: Active filter chips and Reset all always visible on desktop.
+ * #177: Redesigned control bar with text search, due date filter, label chips,
+ * and 3-dot menu with views/grouping/settings sections.
  */
 export function ControlBar() {
   const [filtersExpanded, setFiltersExpanded] = useState(false);
-  const [chipsExpanded, setChipsExpanded] = useState(false);
-  const chipContainerRef = useRef<HTMLDivElement>(null);
-  const [overflowCount, setOverflowCount] = useState(0);
+  const [localSearch, setLocalSearch] = useState('');
+  const searchRef = useRef<HTMLInputElement>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // 3-dot overflow menu state
   const [menuOpen, setMenuOpen] = useState(false);
   const menuBtnRef = useRef<HTMLButtonElement>(null);
   const menuDropdownRef = useRef<HTMLDivElement>(null);
 
-  // Detect if we're on mobile (for filter toggle visibility and label omission)
+  // Detect mobile
   const [isMobile, setIsMobile] = useState(
     typeof window !== 'undefined' ? window.innerWidth <= 768 : false
   );
@@ -34,7 +34,7 @@ export function ControlBar() {
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
-  // AC9: Click-outside to dismiss 3-dot menu
+  // Click-outside to dismiss 3-dot menu
   useEffect(() => {
     if (!menuOpen) return;
     const handleClickOutside = (e: MouseEvent) => {
@@ -49,7 +49,7 @@ export function ControlBar() {
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [menuOpen]);
 
-  // AC8: Escape and arrow key navigation in 3-dot menu
+  // Escape and arrow key navigation in 3-dot menu
   useEffect(() => {
     if (!menuOpen) return;
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -60,7 +60,7 @@ export function ControlBar() {
       }
       if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
         e.preventDefault();
-        const items = menuDropdownRef.current?.querySelectorAll<HTMLElement>('[role="menuitem"]');
+        const items = menuDropdownRef.current?.querySelectorAll<HTMLElement>('[role="menuitem"], [role="menuitemradio"]');
         if (!items || items.length === 0) return;
         const focused = document.activeElement as HTMLElement;
         const idx = Array.from(items).indexOf(focused);
@@ -75,38 +75,44 @@ export function ControlBar() {
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [menuOpen]);
 
-  // Build active filter chip data
-  const activeChips = getActiveChips();
-
-  // AC3: Measure chip overflow
-  useEffect(() => {
-    if (chipsExpanded || !chipContainerRef.current) {
-      setOverflowCount(0);
-      return;
-    }
-    const container = chipContainerRef.current;
-    const chips = container.querySelectorAll<HTMLElement>('.control-bar-chip');
-    if (chips.length === 0) {
-      setOverflowCount(0);
-      return;
-    }
-    const containerRight = container.getBoundingClientRect().right;
-    let hidden = 0;
-    chips.forEach(chip => {
-      if (chip.getBoundingClientRect().right > containerRight) {
-        hidden++;
-      }
-    });
-    setOverflowCount(hidden);
-  }, [activeChips.length, chipsExpanded]);
-
-  // Reset expanded state on board switch
+  // Reset state on board switch
   const currentBoardId = activeBoardId.value;
   useEffect(() => {
-    setChipsExpanded(false);
     setFiltersExpanded(false);
     setMenuOpen(false);
+    setLocalSearch('');
   }, [currentBoardId]);
+
+  // Sync localSearch from signal (e.g. after board switch clears it)
+  useEffect(() => {
+    if (filterSearch.value === '' && localSearch !== '') {
+      setLocalSearch('');
+    }
+  }, [filterSearch.value]);
+
+  // Debounced search
+  const handleSearchInput = useCallback((e: Event) => {
+    const value = (e.target as HTMLInputElement).value;
+    setLocalSearch(value);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      filterSearch.value = value;
+    }, 150);
+  }, []);
+
+  const clearSearch = useCallback(() => {
+    setLocalSearch('');
+    filterSearch.value = '';
+    searchRef.current?.focus();
+  }, []);
+
+  // Escape in search input clears it
+  const handleSearchKeyDown = useCallback((e: KeyboardEvent) => {
+    if (e.key === 'Escape' && localSearch) {
+      e.preventDefault();
+      clearSearch();
+    }
+  }, [localSearch, clearSearch]);
 
   const handleBoardChange = (e: Event) => {
     const value = (e.target as HTMLSelectElement).value;
@@ -118,18 +124,17 @@ export function ControlBar() {
     switchBoard(value);
   };
 
-  const boardName = activeBoard.value?.name || 'board';
   const boardColor = activeBoard.value?.color || '';
   const isOwner = userBoardRole.value === 'owner';
 
-  const hasFilters = filterOwner.value || filterLabel.value;
-  const hasGrouping = groupBy.value !== 'none';
-  const showReset = hasFilters || hasGrouping;
-
+  // Active filter count for mobile badge
   const activeCount =
-    (filterOwner.value ? 1 : 0) +
-    (filterLabel.value ? 1 : 0) +
-    (hasGrouping ? 1 : 0);
+    (filterSearch.value ? 1 : 0) +
+    (filterDue.value ? 1 : 0) +
+    (filterLabel.value ? 1 : 0);
+
+  // Filtered card count for live region
+  const filteredCount = rootItems.value.length;
 
   // Empty boards: show new board button only
   if (boards.value.length === 0) {
@@ -145,12 +150,20 @@ export function ControlBar() {
     );
   }
 
-  // AC3: Filter content collapsed only on mobile when toggle not expanded
   const filterContentClass = `control-bar-filter-content${isMobile && !filtersExpanded ? ' control-bar-filter-content-collapsed' : ''}`;
+
+  const handleDueClick = (due: 'today' | 'this-week') => {
+    filterDue.value = filterDue.value === due ? null : due;
+  };
+
+  const handleGroupClick = (mode: 'none' | 'label') => {
+    groupBy.value = mode;
+    setMenuOpen(false);
+  };
 
   return (
     <div class="control-bar" data-testid="control-bar">
-      {/* Board selector section */}
+      {/* Board selector */}
       <div class="control-bar-section">
         {boardColor && (
           <span
@@ -179,12 +192,11 @@ export function ControlBar() {
         </select>
       </div>
 
-      {/* Separator */}
       <span class="control-bar-separator" aria-hidden="true" />
 
       {/* Filters section */}
       <div class="control-bar-section control-bar-filters">
-        {/* AC3: Filters toggle button — only visible on mobile */}
+        {/* Mobile: Filters toggle */}
         <button
           class="filter-toggle"
           aria-expanded={filtersExpanded}
@@ -196,25 +208,51 @@ export function ControlBar() {
           {activeCount > 0 && <span class="filter-badge">{activeCount}</span>}
         </button>
 
-        {/* AC1/AC2: Filter chips inline — always visible on desktop, toggleable on mobile */}
         <div
           id="control-bar-filter-content"
           class={filterContentClass}
           data-testid="control-bar-filter-content"
         >
-          {/* Owner chips */}
-          <div role="group" aria-label="Filter by owner" class="filter-chip-group">
-            <span class="filter-chip-group-label">Owner:</span>
-            {owners.value.map(o => {
-              const active = filterOwner.value === o.name;
+          {/* AC1: Search input */}
+          <div class="filter-search-wrapper" data-testid="filter-search-wrapper">
+            <input
+              ref={searchRef}
+              type="text"
+              class="filter-search-input"
+              placeholder="Search cards..."
+              aria-label="Search cards"
+              value={localSearch}
+              onInput={handleSearchInput}
+              onKeyDown={handleSearchKeyDown}
+              data-testid="filter-search-input"
+            />
+            {localSearch && (
+              <button
+                class="filter-search-clear"
+                aria-label="Clear search"
+                onClick={clearSearch}
+                data-testid="filter-search-clear"
+              >
+                &times;
+              </button>
+            )}
+          </div>
+
+          {/* AC4/AC5: Due date chips */}
+          <div role="group" aria-label="Filter by due date" class="filter-chip-group" data-testid="filter-due-group">
+            <span class="filter-chip-group-label">Due:</span>
+            {(['today', 'this-week'] as const).map(due => {
+              const active = filterDue.value === due;
+              const label = due === 'today' ? 'Today' : 'This Week';
               return (
                 <button
-                  key={o.name}
-                  class={`filter-chip filter-chip-owner${active ? ' filter-chip-active' : ''}`}
+                  key={due}
+                  class={`filter-chip filter-chip-due${active ? ' filter-chip-active' : ''}`}
                   aria-pressed={active ? 'true' : 'false'}
-                  onClick={() => { filterOwner.value = active ? null : o.name; }}
+                  onClick={() => handleDueClick(due)}
+                  data-testid={`filter-due-${due}`}
                 >
-                  {o.name}
+                  {label}
                 </button>
               );
             })}
@@ -238,85 +276,15 @@ export function ControlBar() {
               );
             })}
           </div>
-
-          {/* Group-by chips */}
-          <div role="group" aria-label="Group by" class="filter-chip-group filter-chip-group-separator">
-            <span class="filter-chip-group-label">Group:</span>
-            {(['owner', 'label'] as const).map(mode => {
-              const active = groupBy.value === mode;
-              const label = mode === 'owner' ? 'Owner' : 'Label';
-              return (
-                <button
-                  key={mode}
-                  class={`filter-chip filter-chip-group-by${active ? ' filter-chip-active' : ''}`}
-                  aria-pressed={active ? 'true' : 'false'}
-                  onClick={() => { groupBy.value = active ? 'none' : mode; }}
-                >
-                  {label}
-                </button>
-              );
-            })}
-          </div>
-
-          {/* AC10: Reset all always visible on desktop when filters active */}
-          {showReset && (
-            <button
-              class="btn btn-ghost btn-sm"
-              onClick={() => {
-                filterOwner.value = null;
-                filterLabel.value = null;
-                groupBy.value = 'none';
-              }}
-              data-testid="control-bar-reset"
-            >
-              Reset all
-            </button>
-          )}
         </div>
 
-        {/* Active filter chips inline */}
-        {activeChips.length > 0 && (
-          <div
-            class={`control-bar-active-chips${chipsExpanded ? ' control-bar-active-chips-expanded' : ''}`}
-            ref={chipContainerRef}
-            data-testid="control-bar-active-chips"
-          >
-            {activeChips.map(chip => (
-              <span key={chip.key} class="control-bar-chip" data-testid="control-bar-chip">
-                {chip.label}
-                <button
-                  class="control-bar-chip-remove"
-                  aria-label={`Remove ${chip.label} filter`}
-                  onClick={chip.onRemove}
-                >
-                  &times;
-                </button>
-              </span>
-            ))}
-            {overflowCount > 0 && !chipsExpanded && (
-              <button
-                class="control-bar-chip-more"
-                aria-label={`Show ${overflowCount} more active filters`}
-                onClick={() => setChipsExpanded(true)}
-                data-testid="control-bar-chip-more"
-              >
-                +{overflowCount} more
-              </button>
-            )}
-            {chipsExpanded && (
-              <button
-                class="control-bar-chip-more"
-                onClick={() => setChipsExpanded(false)}
-                data-testid="control-bar-chip-less"
-              >
-                Show less
-              </button>
-            )}
-          </div>
-        )}
+        {/* AC10: Live region for screen readers */}
+        <div aria-live="polite" class="sr-only" data-testid="filter-live-region">
+          {(filterSearch.value || filterDue.value || filterLabel.value) ? `${filteredCount} cards shown` : ''}
+        </div>
       </div>
 
-      {/* AC4: 3-dot overflow menu */}
+      {/* 3-dot overflow menu */}
       <div class="control-bar-overflow" data-testid="control-bar-overflow">
         <button
           ref={menuBtnRef}
@@ -336,7 +304,8 @@ export function ControlBar() {
             class="overflow-menu-dropdown"
             data-testid="overflow-menu-dropdown"
           >
-            {/* AC4/AC5: View toggle items */}
+            {/* VIEWS section */}
+            <div class="overflow-menu-section-header" role="presentation">Views</div>
             <button
               role="menuitem"
               class={`overflow-menu-item${viewMode.value === 'board' ? ' overflow-menu-item-checked' : ''}`}
@@ -355,16 +324,44 @@ export function ControlBar() {
             >
               List view
             </button>
-            {/* AC6/AC7: Board Settings — owners only */}
+
+            <hr class="overflow-menu-divider" />
+
+            {/* GROUPING section */}
+            <div class="overflow-menu-section-header" role="presentation">Grouping</div>
+            <button
+              role="menuitemradio"
+              class={`overflow-menu-item${groupBy.value === 'none' ? ' overflow-menu-item-checked' : ''}`}
+              aria-checked={groupBy.value === 'none'}
+              onClick={() => handleGroupClick('none')}
+              data-testid="overflow-menu-group-none"
+            >
+              None
+            </button>
+            <button
+              role="menuitemradio"
+              class={`overflow-menu-item${groupBy.value === 'label' ? ' overflow-menu-item-checked' : ''}`}
+              aria-checked={groupBy.value === 'label'}
+              onClick={() => handleGroupClick('label')}
+              data-testid="overflow-menu-group-label"
+            >
+              By Label
+            </button>
+
+            {/* SETTINGS section — owners only */}
             {isOwner && (
-              <button
-                role="menuitem"
-                class="overflow-menu-item"
-                onClick={() => { showShareModal.value = true; setMenuOpen(false); }}
-                data-testid="overflow-menu-board-settings"
-              >
-                Board Settings
-              </button>
+              <>
+                <hr class="overflow-menu-divider" />
+                <div class="overflow-menu-section-header" role="presentation">Settings</div>
+                <button
+                  role="menuitem"
+                  class="overflow-menu-item"
+                  onClick={() => { showShareModal.value = true; setMenuOpen(false); }}
+                  data-testid="overflow-menu-board-settings"
+                >
+                  Board Settings
+                </button>
+              </>
             )}
           </div>
         )}
@@ -378,37 +375,4 @@ const BOARD_SWITCHER_HINT = 'Ctrl+1–9 to switch boards · Press ? for all shor
 function boardOptionLabel(name: string, icon?: string): string {
   const prefix = icon ? `${icon} ` : '';
   return `${prefix}${name}`;
-}
-
-interface ActiveChip {
-  key: string;
-  label: string;
-  onRemove: () => void;
-}
-
-function getActiveChips(): ActiveChip[] {
-  const chips: ActiveChip[] = [];
-  if (filterOwner.value) {
-    chips.push({
-      key: `owner-${filterOwner.value}`,
-      label: `Owner: ${filterOwner.value}`,
-      onRemove: () => { filterOwner.value = null; },
-    });
-  }
-  if (filterLabel.value) {
-    chips.push({
-      key: `label-${filterLabel.value}`,
-      label: `Label: ${filterLabel.value}`,
-      onRemove: () => { filterLabel.value = null; },
-    });
-  }
-  if (groupBy.value !== 'none') {
-    const label = groupBy.value === 'owner' ? 'Owner' : 'Label';
-    chips.push({
-      key: `group-${groupBy.value}`,
-      label: `Group: ${label}`,
-      onRemove: () => { groupBy.value = 'none'; },
-    });
-  }
-  return chips;
 }

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -592,6 +592,89 @@ body {
   font-weight: 600;
 }
 
+/* === Search Input (#177) === */
+.filter-search-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+  flex: 1;
+  min-width: 160px;
+}
+
+.filter-search-input {
+  width: 100%;
+  padding: 4px 32px 4px 12px;
+  border: 2px solid var(--color-border);
+  border-radius: 14px;
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-size: 13px;
+  font-family: inherit;
+  line-height: 1.5;
+  outline: none;
+}
+
+.filter-search-input::placeholder {
+  color: var(--color-text-secondary);
+}
+
+.filter-search-input:focus-visible {
+  border-color: var(--color-primary);
+  box-shadow: var(--focus-ring);
+}
+
+.filter-search-clear {
+  position: absolute;
+  right: 6px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border: none;
+  background: none;
+  color: var(--color-text-secondary);
+  font-size: 16px;
+  cursor: pointer;
+  padding: 0;
+  border-radius: 50%;
+}
+
+.filter-search-clear:hover {
+  background: var(--overlay-md);
+  color: var(--color-text);
+}
+
+/* === Menu Section Headers & Dividers (#177) === */
+.overflow-menu-section-header {
+  padding: 6px 12px 2px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.overflow-menu-divider {
+  border: none;
+  border-top: 1px solid var(--color-border);
+  margin: 4px 0;
+}
+
+/* === Due filter chips (#177) === */
+.filter-chip-due.filter-chip-active {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: white;
+}
+
+.filter-chip-due.filter-chip-active:hover {
+  background: var(--color-primary-hover);
+  border-color: var(--color-primary-hover);
+}
+
 /* Active filter chips inline */
 .control-bar-active-chips {
   display: flex;
@@ -3098,6 +3181,18 @@ body {
     min-height: 44px;
     display: inline-flex;
     align-items: center;
+  }
+
+  /* #177: Search input touch-friendly on mobile */
+  .filter-search-input {
+    min-height: 44px;
+    font-size: 16px;
+  }
+
+  /* #177: Search wrapper full width on mobile */
+  .filter-search-wrapper {
+    width: 100%;
+    flex: unset;
   }
 
   /* AC5: Mobile card spacing >= 10px gap */

--- a/frontend/src/state/board-store.test.ts
+++ b/frontend/src/state/board-store.test.ts
@@ -117,6 +117,126 @@ describe('Archive dialog sorting (AC3)', () => {
   });
 });
 
+// --- #177: Text search and due date filter ---
+
+describe('#177 AC2/AC3: Text search filter', () => {
+  it('filterSearch filters by title (case-insensitive)', async () => {
+    const store = await import('./board-store');
+    store.items.value = [
+      makeItem({ id: 'a', title: 'Grocery shopping', status: 'To Do', parent_id: '' }),
+      makeItem({ id: 'b', title: 'Fix bike', status: 'To Do', parent_id: '' }),
+    ];
+    store.filterSearch.value = 'grocery';
+    const roots = store.rootItems.value;
+    expect(roots.map(i => i.id)).toEqual(['a']);
+    store.filterSearch.value = '';
+  });
+
+  it('filterSearch filters by description', async () => {
+    const store = await import('./board-store');
+    store.items.value = [
+      makeItem({ id: 'a', title: 'Task A', description: 'Buy organic milk', status: 'To Do', parent_id: '' }),
+      makeItem({ id: 'b', title: 'Task B', description: 'Clean house', status: 'To Do', parent_id: '' }),
+    ];
+    store.filterSearch.value = 'milk';
+    expect(store.rootItems.value.map(i => i.id)).toEqual(['a']);
+    store.filterSearch.value = '';
+  });
+
+  it('filterSearch filters by labels', async () => {
+    const store = await import('./board-store');
+    store.items.value = [
+      makeItem({ id: 'a', title: 'Task A', labels: 'Urgent, Home', status: 'To Do', parent_id: '' }),
+      makeItem({ id: 'b', title: 'Task B', labels: 'Work', status: 'To Do', parent_id: '' }),
+    ];
+    store.filterSearch.value = 'urgent';
+    expect(store.rootItems.value.map(i => i.id)).toEqual(['a']);
+    store.filterSearch.value = '';
+  });
+
+  it('AC3: search matches sub-item title, shows parent', async () => {
+    const store = await import('./board-store');
+    store.items.value = [
+      makeItem({ id: 'parent', title: 'Groceries', status: 'To Do', parent_id: '' }),
+      makeItem({ id: 'child', title: 'Buy milk', status: 'To Do', parent_id: 'parent' }),
+      makeItem({ id: 'other', title: 'Fix bike', status: 'To Do', parent_id: '' }),
+    ];
+    store.filterSearch.value = 'milk';
+    const roots = store.rootItems.value;
+    expect(roots.map(i => i.id)).toEqual(['parent']);
+    store.filterSearch.value = '';
+  });
+});
+
+describe('#177 AC4/AC5: Due date filter', () => {
+  function todayStr(): string {
+    const d = new Date();
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+  }
+
+  function tomorrowStr(): string {
+    const d = new Date();
+    d.setDate(d.getDate() + 1);
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+  }
+
+  function nextWeekStr(): string {
+    const d = new Date();
+    d.setDate(d.getDate() + 10);
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+  }
+
+  it('AC4: filterDue="today" shows only items due today', async () => {
+    const store = await import('./board-store');
+    store.items.value = [
+      makeItem({ id: 'today', title: 'Due today', due_date: todayStr(), status: 'To Do', parent_id: '' }),
+      makeItem({ id: 'tomorrow', title: 'Due tomorrow', due_date: tomorrowStr(), status: 'To Do', parent_id: '' }),
+      makeItem({ id: 'nodate', title: 'No due', due_date: '', status: 'To Do', parent_id: '' }),
+    ];
+    store.filterDue.value = 'today';
+    expect(store.rootItems.value.map(i => i.id)).toEqual(['today']);
+    store.filterDue.value = null;
+  });
+
+  it('AC5: filterDue="this-week" shows items due today through Sunday', async () => {
+    const store = await import('./board-store');
+    store.items.value = [
+      makeItem({ id: 'today', title: 'Due today', due_date: todayStr(), status: 'To Do', parent_id: '' }),
+      makeItem({ id: 'tomorrow', title: 'Due tomorrow', due_date: tomorrowStr(), status: 'To Do', parent_id: '' }),
+      makeItem({ id: 'far', title: 'Due next week', due_date: nextWeekStr(), status: 'To Do', parent_id: '' }),
+    ];
+    store.filterDue.value = 'this-week';
+    const roots = store.rootItems.value;
+    // Today and tomorrow should be within this week (10 days out should not)
+    expect(roots.some(i => i.id === 'today')).toBe(true);
+    expect(roots.some(i => i.id === 'far')).toBe(false);
+    store.filterDue.value = null;
+  });
+});
+
+describe('#177 AC6: Filters combine (AND)', () => {
+  it('search + label + due all combine', async () => {
+    const store = await import('./board-store');
+    const today = (() => {
+      const d = new Date();
+      return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+    })();
+    store.items.value = [
+      makeItem({ id: 'match', title: 'Grocery run', labels: 'Urgent', due_date: today, status: 'To Do', parent_id: '' }),
+      makeItem({ id: 'no-label', title: 'Grocery run', labels: 'Home', due_date: today, status: 'To Do', parent_id: '' }),
+      makeItem({ id: 'no-search', title: 'Fix bike', labels: 'Urgent', due_date: today, status: 'To Do', parent_id: '' }),
+      makeItem({ id: 'no-due', title: 'Grocery run', labels: 'Urgent', due_date: '', status: 'To Do', parent_id: '' }),
+    ];
+    store.filterSearch.value = 'grocery';
+    store.filterLabel.value = 'Urgent';
+    store.filterDue.value = 'today';
+    expect(store.rootItems.value.map(i => i.id)).toEqual(['match']);
+    store.filterSearch.value = '';
+    store.filterLabel.value = null;
+    store.filterDue.value = null;
+  });
+});
+
 // We need to test the actual store, not a mock.
 // To do this, we need to re-import the module for each test group
 // since the signal is created at module load time.

--- a/frontend/src/state/board-store.ts
+++ b/frontend/src/state/board-store.ts
@@ -64,6 +64,9 @@ export const boardItems = computed(() => {
 // --- Filters ---
 export const filterOwner = signal<string | null>(null);
 export const filterLabel = signal<string | null>(null);
+export const filterSearch = signal('');
+export type DueFilter = 'today' | 'this-week' | null;
+export const filterDue = signal<DueFilter>(null);
 export const groupBy = signal<'none' | 'owner' | 'label'>('none');
 
 // --- UI state ---
@@ -135,17 +138,82 @@ export function cycleTheme() {
 }
 
 // --- Derived ---
+
+/** Get today's date as YYYY-MM-DD. */
+function todayStr(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+/** Get end-of-week (Sunday) date as YYYY-MM-DD from today. */
+function endOfWeekStr(): string {
+  const d = new Date();
+  const day = d.getDay(); // 0=Sun
+  const diff = day === 0 ? 0 : 7 - day;
+  d.setDate(d.getDate() + diff);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+/** Check if an item's fields match the search term (case-insensitive). */
+function itemMatchesSearch(item: ItemWithRow, term: string): boolean {
+  const t = term.toLowerCase();
+  return (
+    item.title.toLowerCase().includes(t) ||
+    item.description.toLowerCase().includes(t) ||
+    item.labels.toLowerCase().includes(t)
+  );
+}
+
+/** Check if an item's due_date falls within the due filter range. */
+function itemMatchesDue(item: ItemWithRow, due: 'today' | 'this-week'): boolean {
+  if (!item.due_date) return false;
+  const today = todayStr();
+  if (due === 'today') return item.due_date === today;
+  // this-week: today through Sunday inclusive
+  return item.due_date >= today && item.due_date <= endOfWeekStr();
+}
+
 export const filteredItems = computed(() => {
   let result = boardItems.value;
 
-  if (filterOwner.value) {
-    result = result.filter(i => i.owner === filterOwner.value);
-  }
   if (filterLabel.value) {
     const label = filterLabel.value;
     result = result.filter(i =>
       i.labels.split(',').map(l => l.trim()).includes(label)
     );
+  }
+
+  const search = filterSearch.value.trim();
+  const due = filterDue.value;
+
+  if (search || due) {
+    // Build set of root IDs whose children match (for sub-item search)
+    const allItems = boardItems.value;
+    const matchingParentIds = new Set<string>();
+
+    if (search) {
+      for (const item of allItems) {
+        if (item.parent_id && itemMatchesSearch(item, search)) {
+          matchingParentIds.add(item.parent_id);
+        }
+      }
+    }
+    if (due) {
+      for (const item of allItems) {
+        if (item.parent_id && itemMatchesDue(item, due)) {
+          matchingParentIds.add(item.parent_id);
+        }
+      }
+    }
+
+    result = result.filter(i => {
+      // Children pass through — they're filtered out by rootItems
+      if (i.parent_id) return true;
+
+      const searchOk = !search || itemMatchesSearch(i, search) || matchingParentIds.has(i.id);
+      const dueOk = !due || itemMatchesDue(i, due) || matchingParentIds.has(i.id);
+      return searchOk && dueOk;
+    });
   }
 
   return result;
@@ -207,6 +275,8 @@ export function switchBoard(boardId: string) {
   activeBoardId.value = boardId;
   filterOwner.value = null;
   filterLabel.value = null;
+  filterSearch.value = '';
+  filterDue.value = null;
   groupBy.value = 'none';
   selectedItemId.value = null;
 


### PR DESCRIPTION
Closes #177

## Changes
- **Text search**: New `filterSearch` signal with debounced input (150ms). Searches item title, description, labels, and sub-item titles (AC1–AC3)
- **Due date filter**: New `filterDue` signal with "Today" and "This Week" chip toggles (AC4–AC5)
- **Filter combination**: All filters AND-combine (search + due + label) (AC6)
- **Owner removed**: Owner chip group removed from filter bar (AC7)
- **Menu reorganization**: Grouping moved into 3-dot menu with section headers (Views, Grouping, Settings) using `menuitemradio` semantics (AC8)
- **Mobile responsive**: Search, due, and label chips behind Filters toggle on mobile with badge count (AC9)
- **Accessibility**: `aria-label` on search input, `aria-live` region for filtered count, Escape to clear (AC10)
- **Cleanup**: Removed active filter chip row, Reset all button, and owner-related filter logic

## Test coverage
- 974/975 tests pass (1 pre-existing favicon test failure unrelated to this PR)
- Store-level tests for search, due, and combined filtering
- Control-bar tests for all 10 ACs
- tsc and production build clean