### PR TITLE
Fix: Column count badge padding too tight

### DIFF
--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -946,7 +946,7 @@ body {
   color: var(--color-text);
   font-size: 12px;
   font-weight: 600;
-  padding: 2px 8px;
+  padding: 4px 8px;
   border-radius: 10px;
 }
 
@@ -2749,7 +2749,7 @@ body {
   color: var(--color-text-secondary);
   font-size: 12px;
   font-weight: 600;
-  padding: 2px 8px;
+  padding: 4px 8px;
   border-radius: 10px;
 }
 


### PR DESCRIPTION
Closes #176

## Changes
- Updated `.column-count` padding from `2px 8px` to `4px 8px` in `global.css`
- Updated `.list-section-count` padding from `2px 8px` to `4px 8px` to match