### PR TITLE
fix: remove lock icon from date-sorted cards

### DIFF
--- a/frontend/src/components/board/card.tsx
+++ b/frontend/src/components/board/card.tsx
@@ -1,7 +1,6 @@
 import { selectedItemId, getChildCount, openDetailWithTitleEdit } from '../../state/board-store';
 import { labels as labelsStore } from '../../state/board-store';
 import type { ItemWithRow, ItemStatus } from '../../api/types';
-import type { SortMode } from '../../state/board-store';
 import { LabelBadge } from '../shared/label-badge';
 import { KebabMenu } from './kebab-menu';
 import type { KebabAction } from './kebab-menu';
@@ -17,8 +16,6 @@ interface Props {
   onMoveStatus?: (itemId: string, newStatus: ItemStatus) => void;
   onReorder?: (itemId: string, direction: 'up' | 'down') => void;
   columnItems?: ItemWithRow[];
-  /** AC9: Current sort mode — shows lock indicator when non-custom */
-  sortMode?: SortMode;
   /** Kebab menu: move to top of column */
   onMoveToTop?: (itemId: string) => void;
   /** Kebab menu: move to bottom of column */
@@ -27,7 +24,7 @@ interface Props {
   onDelete?: (itemId: string) => void;
 }
 
-export function Card({ item, onMoveStatus, onReorder, columnItems, sortMode, onMoveToTop, onMoveToBottom, onDelete }: Props) {
+export function Card({ item, onMoveStatus, onReorder, columnItems, onMoveToTop, onMoveToBottom, onDelete }: Props) {
   const childCount = getChildCount(item.id);
   const itemLabels = item.labels
     ? item.labels.split(',').map(l => l.trim()).filter(Boolean)
@@ -96,8 +93,6 @@ export function Card({ item, onMoveStatus, onReorder, columnItems, sortMode, onM
     }
   };
 
-  const isDateSorted = sortMode && sortMode !== 'custom';
-
   // Build kebab menu actions
   const isFirstInColumn = columnItems ? columnItems[0]?.id === item.id : false;
   const isLastInColumn = columnItems ? columnItems[columnItems.length - 1]?.id === item.id : false;
@@ -135,16 +130,6 @@ export function Card({ item, onMoveStatus, onReorder, columnItems, sortMode, onM
       data-item-id={item.id}
     >
       <div class="card-content">
-        {/* AC9: Lock indicator when column is in date-sort mode */}
-        {isDateSorted && (
-          <span
-            class="card-sort-lock"
-            title="Manual reorder unavailable in this sort mode"
-            aria-label="Manual reorder unavailable in this sort mode"
-          >
-            &#128274;
-          </span>
-        )}
         {kebabActions.length > 0 && (
           <KebabMenu actions={kebabActions} itemTitle={item.title} />
         )}

--- a/frontend/src/components/board/column.tsx
+++ b/frontend/src/components/board/column.tsx
@@ -378,7 +378,6 @@ export function Column({ status, items, onDrop, onReorder, onMoveStatus, compact
               onMoveStatus={handleMoveStatus}
               onReorder={handleKeyboardReorder}
               columnItems={items}
-              sortMode={sortMode}
               onMoveToTop={onReorder ? handleMoveToTop : undefined}
               onMoveToBottom={onReorder ? handleMoveToBottom : undefined}
               onDelete={onDeleteItem}

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -1213,16 +1213,6 @@ body {
   white-space: nowrap;
 }
 
-/* AC9: Lock indicator on cards in date-sorted columns */
-.card-sort-lock {
-  display: block;
-  font-size: 11px;
-  opacity: 0.45;
-  text-align: right;
-  line-height: 1;
-  margin-bottom: 4px;
-}
-
 /* === Kebab Menu === */
 .kebab-menu-container {
   position: absolute;


### PR DESCRIPTION
Closes #178

## Changes
- Removed `sortMode` prop from Card's Props interface and destructuring
- Removed `isDateSorted` computed variable and lock icon JSX from Card
- Removed `sortMode={sortMode}` pass-through from Column to Card
- Removed `.card-sort-lock` CSS rule from global.css
- SortMode type import removed from card.tsx (no longer needed)

## Test plan
- [x] All 975 frontend tests pass (including existing AC1-3 test asserting no `.card-sort-lock`)
- [x] All 18 apps-script tests pass
- [x] TypeScript check clean (`tsc --noEmit`)
- [x] Production build clean (135KB JS, 48KB CSS)