### PR TITLE
feat: Settings page with central label management

### DIFF
--- a/frontend/src/components/board/kanban-board.test.tsx
+++ b/frontend/src/components/board/kanban-board.test.tsx
@@ -90,6 +90,7 @@ vi.mock('../../state/board-store', () => ({
     set value(v: boolean) { mockState.showDeleteBoardModal = v; },
   },
   showMoveToBoardModal: { value: false },
+  showSettings: { value: false },
   accessibleBoards: { get value() { return mockState.accessibleBoards; } },
   activeBoard: { value: null },
   userBoardRole: { get value() { return mockState.userBoardRole; } },
@@ -159,6 +160,9 @@ vi.mock('../profile/profile-dialog', () => ({
 }));
 vi.mock('../archive/archive-dialog', () => ({
   ArchiveDialog: () => <div data-testid="archive-dialog" />,
+}));
+vi.mock('../settings/settings-page', () => ({
+  SettingsPage: () => <div data-testid="settings-page" />,
 }));
 vi.mock('../shared/hive-logo', () => ({
   HiveLogo: (props: any) => <svg data-testid="hive-logo" class={props.class} />,

--- a/frontend/src/components/board/kanban-board.tsx
+++ b/frontend/src/components/board/kanban-board.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useMemo, useEffect } from 'preact/hooks';
 import { useAuth } from '../../auth/auth-context';
-import { columns, showCreateModal, createModalInitialStatus, selectedItem, groupBy, rootItems, items, owners, labels as labelsStore, viewMode, setViewMode, allDoneItems, hasArchivedItems, showArchiveDialog, boards, showCreateBoardModal, showShareModal, showDeleteBoardModal, showMoveToBoardModal, boardItems, userBoardRole, accessibleBoards, switchBoard, theme, applyTheme, cycleTheme, columnSortModes, setColumnSortMode, columnAnnouncement, showToast } from '../../state/board-store';
+import { columns, showCreateModal, createModalInitialStatus, selectedItem, groupBy, rootItems, items, owners, labels as labelsStore, viewMode, setViewMode, allDoneItems, hasArchivedItems, showArchiveDialog, showSettings, boards, showCreateBoardModal, showShareModal, showDeleteBoardModal, showMoveToBoardModal, boardItems, userBoardRole, accessibleBoards, switchBoard, theme, applyTheme, cycleTheme, columnSortModes, setColumnSortMode, columnAnnouncement, showToast } from '../../state/board-store';
 import type { SortMode } from '../../state/board-store';
 import { moveItem, reorderItem, createItem, deleteItem } from '../../state/actions';
 import { useKeyboardShortcuts } from '../../hooks/use-keyboard-shortcuts';
@@ -16,6 +16,7 @@ import { MoveToBoardModal } from './move-to-board-modal';
 import { ShortcutsHelp } from './shortcuts-help';
 import { ProfileDialog } from '../profile/profile-dialog';
 import { ArchiveDialog } from '../archive/archive-dialog';
+import { SettingsPage } from '../settings/settings-page';
 import { UserDropdown } from '../header/user-dropdown';
 import { ControlBar } from '../header/control-bar';
 import { HiveLogo } from '../shared/hive-logo';
@@ -54,6 +55,7 @@ export function KanbanBoard() {
     !showCreateModal.value &&
     !showCreateBoardModal.value &&
     !showArchiveDialog.value &&
+    !showSettings.value &&
     !selectedItem.value &&
     !showShortcutsHelp;
 
@@ -290,6 +292,7 @@ export function KanbanBoard() {
               displayName={displayName}
               onSignOut={logout}
               onOpenProfile={() => setShowProfile(true)}
+              onOpenSettings={() => { showSettings.value = true; }}
             />
           )}
         </div>
@@ -327,6 +330,7 @@ export function KanbanBoard() {
       {showShareModal.value && <ShareModal />}
       {showDeleteBoardModal.value && <DeleteBoardModal />}
       {showMoveToBoardModal.value && <MoveToBoardModal />}
+      {showSettings.value && token && <SettingsPage token={token} />}
       {showArchiveDialog.value && <ArchiveDialog onClose={handleCloseArchive} />}
       {showShortcutsHelp && <ShortcutsHelp onClose={() => setShowShortcutsHelp(false)} />}
       {showProfile && user && token && (

--- a/frontend/src/components/header/user-dropdown.tsx
+++ b/frontend/src/components/header/user-dropdown.tsx
@@ -8,13 +8,14 @@ interface UserDropdownProps {
   displayName: string;
   onSignOut: () => void;
   onOpenProfile?: () => void;
+  onOpenSettings?: () => void;
 }
 
 /**
  * AC1: User dropdown replaces separate header controls.
  * Avatar + Name button opens a floating panel with email, theme toggle, and sign out.
  */
-export function UserDropdown({ user, displayName, onSignOut, onOpenProfile }: UserDropdownProps) {
+export function UserDropdown({ user, displayName, onSignOut, onOpenProfile, onOpenSettings }: UserDropdownProps) {
   const [open, setOpen] = useState(false);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
@@ -37,6 +38,11 @@ export function UserDropdown({ user, displayName, onSignOut, onOpenProfile }: Us
     closeDropdown();
     onOpenProfile?.();
   }, [closeDropdown, onOpenProfile]);
+
+  const handleOpenSettings = useCallback(() => {
+    closeDropdown();
+    onOpenSettings?.();
+  }, [closeDropdown, onOpenSettings]);
 
   // Close on Escape
   useEffect(() => {
@@ -142,6 +148,19 @@ export function UserDropdown({ user, displayName, onSignOut, onOpenProfile }: Us
                 data-testid="user-dropdown-edit-profile"
               >
                 Edit profile
+              </button>
+              <hr class="user-dropdown-divider" />
+            </>
+          )}
+          {onOpenSettings && (
+            <>
+              <button
+                class="user-dropdown-settings"
+                role="menuitem"
+                onClick={handleOpenSettings}
+                data-testid="user-dropdown-settings"
+              >
+                Settings
               </button>
               <hr class="user-dropdown-divider" />
             </>

--- a/frontend/src/components/settings/label-settings.test.tsx
+++ b/frontend/src/components/settings/label-settings.test.tsx
@@ -1,0 +1,312 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, waitFor, cleanup } from '@testing-library/preact';
+import { labels, items, loading } from '../../state/board-store';
+import { LabelSettings } from './label-settings';
+import type { Label, ItemWithRow } from '../../api/types';
+
+// Mock the actions module
+vi.mock('../../state/actions', () => ({
+  createLabel: vi.fn().mockResolvedValue(undefined),
+  updateLabel: vi.fn().mockResolvedValue(undefined),
+  deleteLabel: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { createLabel, updateLabel, deleteLabel } from '../../state/actions';
+
+const MOCK_LABELS: Label[] = [
+  { label: 'Errands', color: '#42a5f5' },
+  { label: 'Home', color: '#66bb6a' },
+  { label: 'School', color: '#ffa726' },
+];
+
+function makeItem(overrides: Partial<ItemWithRow> = {}): ItemWithRow {
+  return {
+    id: 'item-1',
+    title: 'Test Item',
+    description: '',
+    status: 'To Do',
+    owner: '',
+    due_date: '',
+    labels: '',
+    parent_id: '',
+    created_at: '2026-01-01',
+    updated_at: '2026-01-01',
+    completed_at: '',
+    sort_order: 1,
+    created_by: 'test@test.com',
+    board_id: 'board-1',
+    sheetRow: 2,
+    ...overrides,
+  };
+}
+
+describe('LabelSettings', () => {
+  beforeEach(() => {
+    labels.value = [...MOCK_LABELS];
+    items.value = [
+      makeItem({ id: 'i1', labels: 'Errands' }),
+      makeItem({ id: 'i2', labels: 'Errands, Home' }),
+      makeItem({ id: 'i3', labels: 'School' }),
+    ];
+    loading.value = false;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // --- AC2: View labels with usage counts ---
+
+  it('renders all labels in a table', () => {
+    const { container } = render(<LabelSettings token="test-token" />);
+    const table = container.querySelector('[data-testid="label-settings-table"]');
+    expect(table).toBeTruthy();
+    const rows = table!.querySelectorAll('tbody tr');
+    expect(rows.length).toBe(3);
+  });
+
+  it('shows label name with color swatch', () => {
+    const { container } = render(<LabelSettings token="test-token" />);
+    const swatches = container.querySelectorAll('.label-settings-swatch');
+    expect(swatches.length).toBe(3);
+    // First swatch should have the color of Errands
+    expect((swatches[0] as HTMLElement).style.backgroundColor).toBeTruthy();
+  });
+
+  it('shows usage count for each label', () => {
+    const { container } = render(<LabelSettings token="test-token" />);
+    const counts = container.querySelectorAll('.label-settings-count');
+    // Errands: 2 items, Home: 1 item, School: 1 item
+    expect(counts[0].textContent).toBe('2');
+    expect(counts[1].textContent).toBe('1');
+    expect(counts[2].textContent).toBe('1');
+  });
+
+  it('shows spinner when loading', () => {
+    loading.value = true;
+    const { container } = render(<LabelSettings token="test-token" />);
+    expect(container.querySelector('[data-testid="label-settings-loading"]')).toBeTruthy();
+    expect(container.querySelector('.spinner')).toBeTruthy();
+  });
+
+  it('shows empty state with create button when no labels', () => {
+    labels.value = [];
+    const { container } = render(<LabelSettings token="test-token" />);
+    expect(container.querySelector('[data-testid="label-settings-empty"]')).toBeTruthy();
+    expect(container.querySelector('[data-testid="label-settings-create-first"]')).toBeTruthy();
+  });
+
+  // --- AC3: Create label ---
+
+  it('shows create form when "New Label" is clicked', () => {
+    const { container } = render(<LabelSettings token="test-token" />);
+    const newBtn = container.querySelector('[data-testid="label-settings-new-btn"]');
+    expect(newBtn).toBeTruthy();
+    fireEvent.click(newBtn!);
+    expect(container.querySelector('[data-testid="label-settings-create-form"]')).toBeTruthy();
+  });
+
+  it('create form has proper label element and aria-describedby', () => {
+    const { container } = render(<LabelSettings token="test-token" />);
+    fireEvent.click(container.querySelector('[data-testid="label-settings-new-btn"]')!);
+    const label = container.querySelector('label[for="label-create-name"]');
+    expect(label).toBeTruthy();
+    expect(label!.textContent).toBe('Label name');
+    const input = container.querySelector('#label-create-name');
+    expect(input).toBeTruthy();
+  });
+
+  it('calls createLabel on save', async () => {
+    const { container } = render(<LabelSettings token="test-token" />);
+    fireEvent.click(container.querySelector('[data-testid="label-settings-new-btn"]')!);
+
+    const input = container.querySelector('[data-testid="label-create-name-input"]') as HTMLInputElement;
+    fireEvent.input(input, { target: { value: 'New Label' } });
+
+    const saveBtn = container.querySelector('[data-testid="label-create-save-btn"]');
+    fireEvent.click(saveBtn!);
+
+    await waitFor(() => {
+      expect(createLabel).toHaveBeenCalledWith('New Label', expect.any(String), 'test-token');
+    });
+  });
+
+  it('shows validation error for duplicate name', () => {
+    const { container } = render(<LabelSettings token="test-token" />);
+    fireEvent.click(container.querySelector('[data-testid="label-settings-new-btn"]')!);
+
+    const input = container.querySelector('[data-testid="label-create-name-input"]') as HTMLInputElement;
+    fireEvent.input(input, { target: { value: 'Errands' } });
+
+    const error = container.querySelector('[data-testid="label-create-error"]');
+    expect(error).toBeTruthy();
+    expect(error!.textContent).toBe('A label with this name already exists');
+  });
+
+  it('shows validation error for duplicate name (case-insensitive)', () => {
+    const { container } = render(<LabelSettings token="test-token" />);
+    fireEvent.click(container.querySelector('[data-testid="label-settings-new-btn"]')!);
+
+    const input = container.querySelector('[data-testid="label-create-name-input"]') as HTMLInputElement;
+    fireEvent.input(input, { target: { value: 'errands' } });
+
+    expect(container.querySelector('[data-testid="label-create-error"]')).toBeTruthy();
+  });
+
+  it('disables save button when name is empty', () => {
+    const { container } = render(<LabelSettings token="test-token" />);
+    fireEvent.click(container.querySelector('[data-testid="label-settings-new-btn"]')!);
+
+    const saveBtn = container.querySelector('[data-testid="label-create-save-btn"]') as HTMLButtonElement;
+    expect(saveBtn.disabled).toBe(true);
+  });
+
+  it('cancels create form on Cancel click', () => {
+    const { container } = render(<LabelSettings token="test-token" />);
+    fireEvent.click(container.querySelector('[data-testid="label-settings-new-btn"]')!);
+    expect(container.querySelector('[data-testid="label-settings-create-form"]')).toBeTruthy();
+
+    const cancelBtn = container.querySelector('.label-settings-create-form .btn-ghost');
+    fireEvent.click(cancelBtn!);
+    expect(container.querySelector('[data-testid="label-settings-create-form"]')).toBeFalsy();
+  });
+
+  it('cancels create form on Escape', () => {
+    const { container } = render(<LabelSettings token="test-token" />);
+    fireEvent.click(container.querySelector('[data-testid="label-settings-new-btn"]')!);
+
+    const input = container.querySelector('[data-testid="label-create-name-input"]')!;
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(container.querySelector('[data-testid="label-settings-create-form"]')).toBeFalsy();
+  });
+
+  it('submits create form on Enter when valid', async () => {
+    const { container } = render(<LabelSettings token="test-token" />);
+    fireEvent.click(container.querySelector('[data-testid="label-settings-new-btn"]')!);
+
+    const input = container.querySelector('[data-testid="label-create-name-input"]') as HTMLInputElement;
+    fireEvent.input(input, { target: { value: 'Fresh' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(createLabel).toHaveBeenCalledWith('Fresh', expect.any(String), 'test-token');
+    });
+  });
+
+  it('create form from empty state works', async () => {
+    labels.value = [];
+    const { container } = render(<LabelSettings token="test-token" />);
+    fireEvent.click(container.querySelector('[data-testid="label-settings-create-first"]')!);
+    expect(container.querySelector('[data-testid="label-settings-create-form"]')).toBeTruthy();
+  });
+
+  // --- AC4: Inline edit ---
+
+  it('shows edit form when Edit button is clicked', () => {
+    const { container } = render(<LabelSettings token="test-token" />);
+    const editBtn = container.querySelector('[data-testid="label-edit-btn-Errands"]');
+    expect(editBtn).toBeTruthy();
+    fireEvent.click(editBtn!);
+    expect(container.querySelector('[data-testid="label-edit-form"]')).toBeTruthy();
+  });
+
+  it('edit form has proper label element', () => {
+    const { container } = render(<LabelSettings token="test-token" />);
+    fireEvent.click(container.querySelector('[data-testid="label-edit-btn-Errands"]')!);
+    const label = container.querySelector('label[for="label-edit-name"]');
+    expect(label).toBeTruthy();
+    expect(label!.textContent).toBe('Label name');
+  });
+
+  it('edit form pre-fills name and shows color grid', () => {
+    const { container } = render(<LabelSettings token="test-token" />);
+    fireEvent.click(container.querySelector('[data-testid="label-edit-btn-Errands"]')!);
+
+    const input = container.querySelector('[data-testid="label-edit-name-input"]') as HTMLInputElement;
+    expect(input.value).toBe('Errands');
+    expect(container.querySelector('.color-swatch-grid')).toBeTruthy();
+  });
+
+  it('calls updateLabel on edit save', async () => {
+    const { container } = render(<LabelSettings token="test-token" />);
+    fireEvent.click(container.querySelector('[data-testid="label-edit-btn-Errands"]')!);
+
+    const input = container.querySelector('[data-testid="label-edit-name-input"]') as HTMLInputElement;
+    fireEvent.input(input, { target: { value: 'Tasks' } });
+
+    fireEvent.click(container.querySelector('[data-testid="label-edit-save-btn"]')!);
+
+    await waitFor(() => {
+      expect(updateLabel).toHaveBeenCalledWith('Errands', 'Tasks', expect.any(String), 'test-token');
+    });
+  });
+
+  it('cancels edit on Escape', () => {
+    const { container } = render(<LabelSettings token="test-token" />);
+    fireEvent.click(container.querySelector('[data-testid="label-edit-btn-Errands"]')!);
+
+    const input = container.querySelector('[data-testid="label-edit-name-input"]')!;
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(container.querySelector('[data-testid="label-edit-form"]')).toBeFalsy();
+  });
+
+  it('edit/delete action buttons have min 44x44 touch target', () => {
+    const { container } = render(<LabelSettings token="test-token" />);
+    const editBtn = container.querySelector('[data-testid="label-edit-btn-Errands"]');
+    expect(editBtn!.classList.contains('label-settings-action-btn')).toBe(true);
+  });
+
+  // --- AC5: Delete with confirmation ---
+
+  it('shows delete confirmation when Delete is clicked', () => {
+    const { container } = render(<LabelSettings token="test-token" />);
+    const deleteBtn = container.querySelector('[data-testid="label-delete-btn-Errands"]');
+    expect(deleteBtn).toBeTruthy();
+    fireEvent.click(deleteBtn!);
+    expect(container.querySelector('[data-testid="label-delete-confirm"]')).toBeTruthy();
+  });
+
+  it('shows usage count in delete confirmation message', () => {
+    const { container } = render(<LabelSettings token="test-token" />);
+    fireEvent.click(container.querySelector('[data-testid="label-delete-btn-Errands"]')!);
+    const message = container.querySelector('[data-testid="label-delete-message"]');
+    // Errands is used by 2 items
+    expect(message!.textContent).toBe('This label is used by 2 items. Remove it from all items and delete?');
+  });
+
+  it('shows singular message when used by 1 item', () => {
+    const { container } = render(<LabelSettings token="test-token" />);
+    fireEvent.click(container.querySelector('[data-testid="label-delete-btn-Home"]')!);
+    const message = container.querySelector('[data-testid="label-delete-message"]');
+    expect(message!.textContent).toBe('This label is used by 1 item. Remove it from all items and delete?');
+  });
+
+  it('shows simple message when label is unused', () => {
+    items.value = []; // No items use any label
+    const { container } = render(<LabelSettings token="test-token" />);
+    fireEvent.click(container.querySelector('[data-testid="label-delete-btn-Errands"]')!);
+    const message = container.querySelector('[data-testid="label-delete-message"]');
+    expect(message!.textContent).toBe('Delete this label?');
+  });
+
+  it('calls deleteLabel on confirm', async () => {
+    const { container } = render(<LabelSettings token="test-token" />);
+    fireEvent.click(container.querySelector('[data-testid="label-delete-btn-Errands"]')!);
+    fireEvent.click(container.querySelector('[data-testid="label-delete-confirm-btn"]')!);
+
+    await waitFor(() => {
+      expect(deleteLabel).toHaveBeenCalledWith('Errands', 'test-token');
+    });
+  });
+
+  it('cancels delete on Cancel click', () => {
+    const { container } = render(<LabelSettings token="test-token" />);
+    fireEvent.click(container.querySelector('[data-testid="label-delete-btn-Errands"]')!);
+    expect(container.querySelector('[data-testid="label-delete-confirm"]')).toBeTruthy();
+
+    const cancelBtn = container.querySelector('.label-settings-delete-confirm .btn-ghost');
+    fireEvent.click(cancelBtn!);
+    expect(container.querySelector('[data-testid="label-delete-confirm"]')).toBeFalsy();
+  });
+});

--- a/frontend/src/components/settings/label-settings.tsx
+++ b/frontend/src/components/settings/label-settings.tsx
@@ -1,0 +1,342 @@
+import { useState, useRef } from 'preact/hooks';
+import { labels as labelsStore, items, loading } from '../../state/board-store';
+import { createLabel, updateLabel, deleteLabel } from '../../state/actions';
+import { getContrastTextColor } from '../../utils/color';
+import { ColorSwatchGrid } from '../labels/color-swatch-grid';
+import { PRESET_COLORS } from '../labels/preset-colors';
+
+interface LabelSettingsProps {
+  token: string;
+}
+
+interface EditState {
+  name: string;
+  color: string;
+  originalName: string;
+}
+
+export function LabelSettings({ token }: LabelSettingsProps) {
+  const [creating, setCreating] = useState(false);
+  const [createName, setCreateName] = useState('');
+  const [createColor, setCreateColor] = useState('');
+  const [editingLabel, setEditingLabel] = useState<string | null>(null);
+  const [editState, setEditState] = useState<EditState | null>(null);
+  const [deletingLabel, setDeletingLabel] = useState<string | null>(null);
+  const createInputRef = useRef<HTMLInputElement>(null);
+  const editInputRef = useRef<HTMLInputElement>(null);
+
+  const allLabels = labelsStore.value;
+  const allItems = items.value;
+
+  const getUsageCount = (labelName: string): number => {
+    return allItems.filter(item => {
+      const labelsList = item.labels.split(',').map(l => l.trim());
+      return labelsList.includes(labelName);
+    }).length;
+  };
+
+  const usedColors = new Set(allLabels.map(l => l.color.toUpperCase()));
+  const firstUnusedColor = PRESET_COLORS.find(pc => !usedColors.has(pc.hex.toUpperCase()))?.hex || PRESET_COLORS[0].hex;
+
+  // --- Validation ---
+  const validateName = (name: string, originalName?: string): string | null => {
+    const trimmed = name.trim();
+    if (!trimmed) return 'Label name is required';
+    if (trimmed.length > 30) return 'Label name must be 30 characters or fewer';
+    const isDuplicate = allLabels.some(
+      l => l.label.toLowerCase() === trimmed.toLowerCase() &&
+        l.label.toLowerCase() !== (originalName || '').toLowerCase()
+    );
+    if (isDuplicate) return 'A label with this name already exists';
+    return null;
+  };
+
+  // --- Create ---
+  const startCreate = () => {
+    setCreating(true);
+    setCreateName('');
+    setCreateColor(firstUnusedColor);
+    setEditingLabel(null);
+    setEditState(null);
+    setDeletingLabel(null);
+    requestAnimationFrame(() => createInputRef.current?.focus());
+  };
+
+  const cancelCreate = () => {
+    setCreating(false);
+    setCreateName('');
+    setCreateColor('');
+  };
+
+  const createValidationError = creating ? validateName(createName) : null;
+  const canCreate = creating && createName.trim() !== '' && !createValidationError && createColor !== '';
+
+  const handleCreate = async () => {
+    if (!canCreate) return;
+    await createLabel(createName.trim(), createColor, token);
+    cancelCreate();
+  };
+
+  // --- Edit ---
+  const startEdit = (labelName: string) => {
+    const label = allLabels.find(l => l.label === labelName);
+    if (!label) return;
+    setEditingLabel(labelName);
+    setEditState({ name: label.label, color: label.color, originalName: label.label });
+    setCreating(false);
+    setDeletingLabel(null);
+    requestAnimationFrame(() => editInputRef.current?.focus());
+  };
+
+  const cancelEdit = () => {
+    setEditingLabel(null);
+    setEditState(null);
+  };
+
+  const editValidationError = editState ? validateName(editState.name, editState.originalName) : null;
+  const canSaveEdit = editState !== null && editState.name.trim() !== '' && !editValidationError && editState.color !== '';
+
+  const handleSaveEdit = async () => {
+    if (!editState || !canSaveEdit) return;
+    await updateLabel(editState.originalName, editState.name.trim(), editState.color, token);
+    cancelEdit();
+  };
+
+  // --- Delete ---
+  const startDelete = (labelName: string) => {
+    setDeletingLabel(labelName);
+    setEditingLabel(null);
+    setEditState(null);
+    setCreating(false);
+  };
+
+  const cancelDelete = () => {
+    setDeletingLabel(null);
+  };
+
+  const confirmDelete = async (labelName: string) => {
+    await deleteLabel(labelName, token);
+    setDeletingLabel(null);
+  };
+
+  // --- Loading ---
+  if (loading.value) {
+    return (
+      <section class="label-settings" data-testid="label-settings" aria-label="Labels">
+        <h3 class="label-settings-heading">Labels</h3>
+        <div class="label-settings-loading" data-testid="label-settings-loading">
+          <span class="spinner" aria-label="Loading labels" />
+        </div>
+      </section>
+    );
+  }
+
+  // --- Empty ---
+  if (allLabels.length === 0 && !creating) {
+    return (
+      <section class="label-settings" data-testid="label-settings" aria-label="Labels">
+        <h3 class="label-settings-heading">Labels</h3>
+        <div class="label-settings-empty" data-testid="label-settings-empty">
+          <p>No labels yet.</p>
+          <button
+            type="button"
+            class="btn btn-primary"
+            onClick={startCreate}
+            data-testid="label-settings-create-first"
+          >
+            Create your first label
+          </button>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section class="label-settings" data-testid="label-settings" aria-label="Labels">
+      <div class="label-settings-header">
+        <h3 class="label-settings-heading">Labels</h3>
+        <button
+          type="button"
+          class="btn btn-primary btn-sm"
+          onClick={startCreate}
+          data-testid="label-settings-new-btn"
+        >
+          New Label
+        </button>
+      </div>
+
+      {creating && (
+        <div class="label-settings-create-form" data-testid="label-settings-create-form">
+          <div class="label-settings-form-field">
+            <label for="label-create-name">Label name</label>
+            <input
+              ref={createInputRef}
+              id="label-create-name"
+              type="text"
+              maxLength={30}
+              value={createName}
+              onInput={(e) => setCreateName((e.target as HTMLInputElement).value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && canCreate) { e.preventDefault(); handleCreate(); }
+                if (e.key === 'Escape') { e.stopPropagation(); cancelCreate(); }
+              }}
+              aria-invalid={createValidationError && createName.trim() !== '' ? 'true' : undefined}
+              aria-describedby={createValidationError && createName.trim() !== '' ? 'label-create-error' : undefined}
+              data-testid="label-create-name-input"
+            />
+            {createValidationError && createName.trim() !== '' && (
+              <span id="label-create-error" class="label-settings-error" role="alert" data-testid="label-create-error">
+                {createValidationError}
+              </span>
+            )}
+          </div>
+          <ColorSwatchGrid selectedColor={createColor} onSelect={setCreateColor} />
+          <div class="label-settings-form-actions">
+            <button type="button" class="btn btn-ghost btn-sm" onClick={cancelCreate}>Cancel</button>
+            <button
+              type="button"
+              class="btn btn-primary btn-sm"
+              disabled={!canCreate}
+              onClick={handleCreate}
+              data-testid="label-create-save-btn"
+            >
+              Create
+            </button>
+          </div>
+        </div>
+      )}
+
+      <table class="label-settings-table" data-testid="label-settings-table">
+        <thead>
+          <tr>
+            <th>Color</th>
+            <th>Name</th>
+            <th>Items</th>
+            <th><span class="sr-only">Actions</span></th>
+          </tr>
+        </thead>
+        <tbody>
+          {allLabels.map(l => {
+            const usageCount = getUsageCount(l.label);
+            const isEditing = editingLabel === l.label;
+            const isDeleting = deletingLabel === l.label;
+
+            if (isEditing && editState) {
+              return (
+                <tr key={l.label} data-testid={`label-row-${l.label}`}>
+                  <td colSpan={4}>
+                    <div class="label-settings-edit-form" data-testid="label-edit-form">
+                      <div class="label-settings-form-field">
+                        <label for="label-edit-name">Label name</label>
+                        <input
+                          ref={editInputRef}
+                          id="label-edit-name"
+                          type="text"
+                          maxLength={30}
+                          value={editState.name}
+                          onInput={(e) => setEditState({ ...editState, name: (e.target as HTMLInputElement).value })}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter' && canSaveEdit) { e.preventDefault(); handleSaveEdit(); }
+                            if (e.key === 'Escape') { e.stopPropagation(); cancelEdit(); }
+                          }}
+                          aria-invalid={editValidationError && editState.name.trim() !== '' ? 'true' : undefined}
+                          aria-describedby={editValidationError && editState.name.trim() !== '' ? 'label-edit-error' : undefined}
+                          data-testid="label-edit-name-input"
+                        />
+                        {editValidationError && editState.name.trim() !== '' && (
+                          <span id="label-edit-error" class="label-settings-error" role="alert" data-testid="label-edit-error">
+                            {editValidationError}
+                          </span>
+                        )}
+                      </div>
+                      <ColorSwatchGrid selectedColor={editState.color} onSelect={(hex) => setEditState({ ...editState, color: hex })} />
+                      <div class="label-settings-form-actions">
+                        <button type="button" class="btn btn-ghost btn-sm" onClick={cancelEdit}>Cancel</button>
+                        <button
+                          type="button"
+                          class="btn btn-primary btn-sm"
+                          disabled={!canSaveEdit}
+                          onClick={handleSaveEdit}
+                          data-testid="label-edit-save-btn"
+                        >
+                          Save
+                        </button>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+              );
+            }
+
+            if (isDeleting) {
+              const deleteMessage = usageCount > 0
+                ? `This label is used by ${usageCount} item${usageCount === 1 ? '' : 's'}. Remove it from all items and delete?`
+                : 'Delete this label?';
+              return (
+                <tr key={l.label} data-testid={`label-row-${l.label}`}>
+                  <td colSpan={4}>
+                    <div class="label-settings-delete-confirm" data-testid="label-delete-confirm">
+                      <span class="label-settings-delete-message" data-testid="label-delete-message">{deleteMessage}</span>
+                      <div class="label-settings-form-actions">
+                        <button type="button" class="btn btn-ghost btn-sm" onClick={cancelDelete}>Cancel</button>
+                        <button
+                          type="button"
+                          class="btn btn-danger btn-sm"
+                          onClick={() => confirmDelete(l.label)}
+                          data-testid="label-delete-confirm-btn"
+                        >
+                          Delete
+                        </button>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+              );
+            }
+
+            return (
+              <tr key={l.label} data-testid={`label-row-${l.label}`}>
+                <td>
+                  <span
+                    class="label-settings-swatch"
+                    style={{ backgroundColor: l.color }}
+                    aria-label={`Color: ${l.color}`}
+                  />
+                </td>
+                <td>
+                  <span
+                    class="label-settings-name"
+                    style={{ '--label-color': l.color, '--label-text-color': getContrastTextColor(l.color) } as any}
+                  >
+                    {l.label}
+                  </span>
+                </td>
+                <td class="label-settings-count">{usageCount}</td>
+                <td class="label-settings-actions">
+                  <button
+                    type="button"
+                    class="btn btn-ghost btn-sm label-settings-action-btn"
+                    onClick={() => startEdit(l.label)}
+                    aria-label={`Edit ${l.label}`}
+                    data-testid={`label-edit-btn-${l.label}`}
+                  >
+                    Edit
+                  </button>
+                  <button
+                    type="button"
+                    class="btn btn-ghost btn-sm label-settings-action-btn label-settings-delete-btn"
+                    onClick={() => startDelete(l.label)}
+                    aria-label={`Delete ${l.label}`}
+                    data-testid={`label-delete-btn-${l.label}`}
+                  >
+                    Delete
+                  </button>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </section>
+  );
+}

--- a/frontend/src/components/settings/settings-page.test.tsx
+++ b/frontend/src/components/settings/settings-page.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/preact';
+import { showSettings } from '../../state/board-store';
+import { SettingsPage } from './settings-page';
+
+// Mock useFocusTrap to avoid side effects in tests
+vi.mock('../../hooks/use-focus-trap', () => ({
+  useFocusTrap: (onEscape?: () => void) => {
+    const ref = { current: null };
+    // Store onEscape for Escape key simulation
+    (globalThis as any).__mockOnEscape = onEscape;
+    return ref;
+  },
+}));
+
+// Mock LabelSettings
+vi.mock('./label-settings', () => ({
+  LabelSettings: ({ token }: { token: string }) => (
+    <div data-testid="label-settings-mock">token={token}</div>
+  ),
+}));
+
+describe('SettingsPage', () => {
+  beforeEach(() => {
+    showSettings.value = true;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+    showSettings.value = false;
+  });
+
+  // AC1: Settings modal renders with heading
+  it('renders a dialog with Settings heading', () => {
+    const { container } = render(<SettingsPage token="test-token" />);
+    const dialog = container.querySelector('[role="dialog"]');
+    expect(dialog).toBeTruthy();
+    expect(dialog!.getAttribute('aria-modal')).toBe('true');
+    expect(dialog!.getAttribute('aria-labelledby')).toBe('settings-heading');
+
+    const heading = container.querySelector('#settings-heading');
+    expect(heading).toBeTruthy();
+    expect(heading!.textContent).toBe('Settings');
+  });
+
+  // AC1: Settings modal has close button
+  it('closes on close button click', () => {
+    const { container } = render(<SettingsPage token="test-token" />);
+    const closeBtn = container.querySelector('[data-testid="settings-close-btn"]');
+    expect(closeBtn).toBeTruthy();
+    fireEvent.click(closeBtn!);
+    expect(showSettings.value).toBe(false);
+  });
+
+  // AC1: Overlay click closes
+  it('closes on overlay click', () => {
+    const { container } = render(<SettingsPage token="test-token" />);
+    const overlay = container.querySelector('.modal-overlay');
+    expect(overlay).toBeTruthy();
+    fireEvent.click(overlay!);
+    expect(showSettings.value).toBe(false);
+  });
+
+  // AC1: Does not close when clicking inside modal
+  it('does not close when clicking inside modal body', () => {
+    const { container } = render(<SettingsPage token="test-token" />);
+    const modal = container.querySelector('.settings-page');
+    fireEvent.click(modal!);
+    expect(showSettings.value).toBe(true);
+  });
+
+  // AC1: Renders LabelSettings with token
+  it('renders LabelSettings component', () => {
+    const { container } = render(<SettingsPage token="my-token" />);
+    const labelSettings = container.querySelector('[data-testid="label-settings-mock"]');
+    expect(labelSettings).toBeTruthy();
+    expect(labelSettings!.textContent).toContain('token=my-token');
+  });
+
+  // AC1: Focus heading has tabIndex for focus management
+  it('heading has tabIndex=-1 and data-autofocus for focus trap', () => {
+    const { container } = render(<SettingsPage token="test-token" />);
+    const heading = container.querySelector('#settings-heading');
+    expect(heading!.getAttribute('tabindex')).toBe('-1');
+    expect(heading!.hasAttribute('data-autofocus')).toBe(true);
+  });
+});

--- a/frontend/src/components/settings/settings-page.tsx
+++ b/frontend/src/components/settings/settings-page.tsx
@@ -1,0 +1,51 @@
+import { useCallback } from 'preact/hooks';
+import { useFocusTrap } from '../../hooks/use-focus-trap';
+import { showSettings } from '../../state/board-store';
+import { LabelSettings } from './label-settings';
+
+interface SettingsPageProps {
+  token: string;
+}
+
+export function SettingsPage({ token }: SettingsPageProps) {
+  const handleClose = useCallback(() => {
+    showSettings.value = false;
+  }, []);
+
+  const trapRef = useFocusTrap(handleClose);
+
+  const handleOverlayClick = (e: Event) => {
+    if ((e.target as HTMLElement).classList.contains('modal-overlay')) {
+      handleClose();
+    }
+  };
+
+  return (
+    <div class="modal-overlay" onClick={handleOverlayClick}>
+      <div
+        class="modal settings-page"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="settings-heading"
+        ref={trapRef}
+        data-testid="settings-modal"
+      >
+        <div class="modal-header">
+          <h2 id="settings-heading" data-autofocus tabIndex={-1}>Settings</h2>
+          <button
+            class="btn btn-ghost"
+            onClick={handleClose}
+            aria-label="Close"
+            data-testid="settings-close-btn"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div class="settings-body">
+          <LabelSettings token={token} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -2601,6 +2601,194 @@ body {
   flex-wrap: wrap;
 }
 
+/* === Settings Page === */
+.settings-page {
+  width: 640px;
+  max-width: 95vw;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.settings-body {
+  padding: 20px;
+  overflow-y: auto;
+  flex: 1;
+}
+
+/* --- Label Settings --- */
+.label-settings {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.label-settings-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.label-settings-heading {
+  font-size: 16px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.label-settings-loading {
+  display: flex;
+  justify-content: center;
+  padding: 32px 0;
+}
+
+.label-settings-empty {
+  text-align: center;
+  padding: 32px 0;
+  color: var(--color-text-secondary);
+}
+
+.label-settings-empty p {
+  margin: 0 0 12px 0;
+}
+
+.label-settings-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.label-settings-table th {
+  text-align: left;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.label-settings-table td {
+  padding: 8px;
+  border-bottom: 1px solid var(--color-border);
+  vertical-align: middle;
+}
+
+.label-settings-swatch {
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  border-radius: 4px;
+  vertical-align: middle;
+}
+
+.label-settings-name {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 4px;
+  background: var(--label-color);
+  color: var(--label-text-color);
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.label-settings-count {
+  text-align: center;
+  color: var(--color-text-secondary);
+  font-size: 13px;
+}
+
+.label-settings-actions {
+  text-align: right;
+  white-space: nowrap;
+}
+
+.label-settings-action-btn {
+  min-width: 44px;
+  min-height: 44px;
+}
+
+.label-settings-delete-btn {
+  color: var(--color-danger, #e74c3c);
+}
+
+/* --- Settings forms (create / edit / delete confirm) --- */
+.label-settings-create-form,
+.label-settings-edit-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px;
+  background: var(--color-surface-raised, var(--color-surface));
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+}
+
+.label-settings-form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.label-settings-form-field label {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+}
+
+.label-settings-form-field input {
+  padding: 6px 8px;
+  font-size: 14px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  background: var(--color-surface);
+  color: var(--color-text);
+}
+
+.label-settings-form-field input[aria-invalid="true"] {
+  border-color: var(--color-danger, #e74c3c);
+}
+
+.label-settings-error {
+  color: var(--color-danger, #e74c3c);
+  font-size: 12px;
+}
+
+.label-settings-form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.label-settings-delete-confirm {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  background: var(--color-surface-raised, var(--color-surface));
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+}
+
+.label-settings-delete-message {
+  font-size: 14px;
+  color: var(--color-text);
+}
+
+/* Settings menu item in user dropdown */
+.user-dropdown-settings {
+  display: block;
+  width: 100%;
+  padding: 8px 12px;
+  background: none;
+  border: none;
+  text-align: left;
+  color: var(--color-text);
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.user-dropdown-settings:hover {
+  background: var(--color-surface-hover);
+}
+
 /* === FAB (Floating Action Button) === */
 .fab {
   position: fixed;

--- a/frontend/src/state/board-store.ts
+++ b/frontend/src/state/board-store.ts
@@ -255,6 +255,9 @@ export const allDoneItemsSorted = computed(() =>
   allDoneItems.value.slice().sort(byCompletedAtDesc)
 );
 
+// --- UI state for settings modal ---
+export const showSettings = signal(false);
+
 // --- UI state for archive dialog ---
 export const showArchiveDialog = signal(false);
 


### PR DESCRIPTION
Closes #182

## Changes
- **New:** `settings-page.tsx` — full-screen Settings modal with focus trap, Escape/overlay dismiss
- **New:** `label-settings.tsx` — Label table with CRUD: create, inline edit, delete with usage-aware confirmation
- **Modified:** `user-dropdown.tsx` — added Settings menu item (visible in demo mode)
- **Modified:** `kanban-board.tsx` — wired Settings modal rendering + `noModalOpen` guard
- **Modified:** `board-store.ts` — added `showSettings` signal
- **Modified:** `global.css` — Settings modal and label management styles
- **Tests:** 33 new tests covering all 5 ACs (settings-page.test.tsx + label-settings.test.tsx)
- **Existing:** Updated kanban-board.test.tsx mock to include `showSettings`

## AC Coverage
| AC | Description | Tests |
|---|---|---|
| AC1 | Navigate to Settings via dropdown, focus trap, Escape/overlay close | 6 tests |
| AC2 | Label table with usage counts, loading spinner, empty state | 4 tests |
| AC3 | Create label with validation, Enter/Escape, color swatch | 8 tests |
| AC4 | Inline edit with pre-fill, save, cancel, touch targets | 5 tests |
| AC5 | Delete with N-item confirmation, confirm/cancel | 5 tests |

## Verification
- All 1008 frontend tests pass
- All 18 apps-script tests pass
- `tsc --noEmit` clean
- `vite build` clean