### PR TITLE
feat: apply unified gold color scheme

### DIFF
--- a/frontend/src/components/shared/hive-logo.test.tsx
+++ b/frontend/src/components/shared/hive-logo.test.tsx
@@ -30,11 +30,11 @@ describe('HiveLogo (Issue #30 AC1)', () => {
     expect(svg!.classList.contains('my-class')).toBe(true);
   });
 
-  it('uses var(--color-primary) as the fill colour', () => {
+  it('uses var(--color-accent) as the fill colour', () => {
     const { container } = render(<HiveLogo />);
     const polygon = container.querySelector('polygon');
     expect(polygon).not.toBeNull();
-    expect(polygon!.getAttribute('fill')).toBe('var(--color-primary)');
+    expect(polygon!.getAttribute('fill')).toBe('var(--color-accent)');
   });
 
   it('contains the hexagon and checkmark shapes', () => {

--- a/frontend/src/components/shared/hive-logo.tsx
+++ b/frontend/src/components/shared/hive-logo.tsx
@@ -13,7 +13,7 @@ export function HiveLogo({ size = 24, class: className }: HiveLogoProps) {
       height={size}
       class={className}
     >
-      <polygon points="12 2 21 7 21 17 12 22 3 17 3 7" fill="var(--color-primary)" />
+      <polygon points="12 2 21 7 21 17 12 22 3 17 3 7" fill="var(--color-accent)" />
       <path
         d="M7 12.5l3.2 3.2L17 9.5"
         fill="none"

--- a/frontend/src/design-tokens.test.ts
+++ b/frontend/src/design-tokens.test.ts
@@ -142,6 +142,99 @@ describe('Design tokens: shared vocabulary (Issue #191)', () => {
   });
 });
 
+describe('Design tokens: gold color scheme (Issue #190)', () => {
+  describe('AC1: Gold primary tokens in light mode', () => {
+    it('--color-primary is #C49200 in :root', () => {
+      expect(rootBlock).toMatch(/--color-primary:\s*#C49200/);
+    });
+    it('--color-primary-hover is #A67B00 in :root', () => {
+      expect(rootBlock).toMatch(/--color-primary-hover:\s*#A67B00/);
+    });
+    it('--color-primary-rgb is 196, 146, 0 in :root', () => {
+      expect(rootBlock).toMatch(/--color-primary-rgb:\s*196, 146, 0/);
+    });
+    it('--color-focus is #C49200 in :root', () => {
+      expect(rootBlock).toMatch(/--color-focus:\s*#C49200/);
+    });
+  });
+
+  describe('AC2: Gold primary tokens in dark mode', () => {
+    it('--color-primary is #F5B700 in dark mode', () => {
+      expect(darkBlock).toMatch(/--color-primary:\s*#F5B700/);
+    });
+    it('--color-primary-hover is #FFD54F in dark mode', () => {
+      expect(darkBlock).toMatch(/--color-primary-hover:\s*#FFD54F/);
+    });
+    it('--color-primary-rgb is 245, 183, 0 in dark mode', () => {
+      expect(darkBlock).toMatch(/--color-primary-rgb:\s*245, 183, 0/);
+    });
+    it('--color-focus is #F5B700 in dark mode', () => {
+      expect(darkBlock).toMatch(/--color-focus:\s*#F5B700/);
+    });
+  });
+
+  describe('AC3: Accent token for logo/branding', () => {
+    it('--color-accent is #F5B700 in :root', () => {
+      expect(rootBlock).toMatch(/--color-accent:\s*#F5B700/);
+    });
+    it('--color-accent is #F5B700 in dark mode', () => {
+      expect(darkBlock).toMatch(/--color-accent:\s*#F5B700/);
+    });
+  });
+
+  describe('AC4: WCAG AA contrast for interactive elements', () => {
+    it('.btn-primary uses dark text (#1f1f1f) not white', () => {
+      const match = css.match(/\.btn-primary\s*\{[^}]*\}/);
+      expect(match).not.toBeNull();
+      expect(match![0]).toContain('color: #1f1f1f');
+      expect(match![0]).not.toContain('color: white');
+    });
+  });
+
+  describe('AC5: No blue primary remnants', () => {
+    it('no #1976d2 in global.css', () => {
+      expect(css).not.toContain('#1976d2');
+    });
+    it('no #90caf9 in global.css', () => {
+      expect(css).not.toContain('#90caf9');
+    });
+    it('no #1565c0 in global.css', () => {
+      expect(css).not.toContain('#1565c0');
+    });
+    it('no #64b5f6 in global.css', () => {
+      expect(css).not.toContain('#64b5f6');
+    });
+    it('.column-sort-active SVG uses gold fill in light mode', () => {
+      const match = css.match(/\.column-sort-active\s*\{[^}]*\}/);
+      expect(match).not.toBeNull();
+      expect(match![0]).toContain("fill='%23C49200'");
+    });
+    it('[data-theme="dark"] .column-sort-active SVG uses gold fill', () => {
+      const match = css.match(/\[data-theme="dark"\]\s*\.column-sort-active\s*\{[^}]*\}/);
+      expect(match).not.toBeNull();
+      expect(match![0]).toContain("fill='%23F5B700'");
+    });
+  });
+
+  describe('AC6: Semantic and neutral tokens unchanged', () => {
+    it('--color-bg is #f0f2f5', () => {
+      expect(rootBlock).toMatch(/--color-bg:\s*#f0f2f5/);
+    });
+    it('--color-surface is #ffffff', () => {
+      expect(rootBlock).toMatch(/--color-surface:\s*#ffffff/);
+    });
+    it('--color-border is #dadce0', () => {
+      expect(rootBlock).toMatch(/--color-border:\s*#dadce0/);
+    });
+    it('--color-text is #1f1f1f', () => {
+      expect(rootBlock).toMatch(/--color-text:\s*#1f1f1f/);
+    });
+    it('--color-text-secondary is #5f6368', () => {
+      expect(rootBlock).toMatch(/--color-text-secondary:\s*#5f6368/);
+    });
+  });
+});
+
 describe('Design token: --color-primary-light (Issue #104)', () => {
   // AC1: Token defined in :root
   describe('AC1: Token defined in :root', () => {

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -4,11 +4,14 @@
   --color-bg: #f0f2f5;
   --color-surface: #ffffff;
 
-  /* Brand colours */
-  --color-primary: #1976d2;
-  --color-primary-hover: #1565c0;
+  /* Brand colours — two-tier system:
+     --color-accent (#F5B700): logo/branding/decorative (same both modes)
+     --color-primary: interactive elements, tuned for WCAG AA contrast per mode */
+  --color-accent: #F5B700;
+  --color-primary: #C49200;
+  --color-primary-hover: #A67B00;
   /* RGB components for alpha-blended highlights */
-  --color-primary-rgb: 25, 118, 210;
+  --color-primary-rgb: 196, 146, 0;
   --color-primary-light: color-mix(in srgb, var(--color-primary) 8%, transparent);
 
   /* Text */
@@ -82,7 +85,7 @@
   --radius-full: 9999px;
   --shadow: 0 1px 3px var(--overlay-3xl), 0 1px 2px var(--overlay-md);
   --shadow-lg: 0 4px 12px var(--overlay-3xl);
-  --color-focus: #1976d2;
+  --color-focus: #C49200;
   --focus-ring: 0 0 0 2px var(--color-focus);
   --column-width: 320px;
   --header-height: 44px;
@@ -94,9 +97,10 @@
   --color-bg: #121212;
   --color-surface: #1e1e1e;
 
-  --color-primary: #90caf9;
-  --color-primary-hover: #64b5f6;
-  --color-primary-rgb: 144, 202, 249;
+  --color-accent: #F5B700;
+  --color-primary: #F5B700;
+  --color-primary-hover: #FFD54F;
+  --color-primary-rgb: 245, 183, 0;
 
   --color-text: #e8eaed;
   --color-text-secondary: #9aa0a6;
@@ -136,7 +140,7 @@
 
   --shadow: 0 1px 3px rgba(0, 0, 0, 0.4), 0 1px 2px rgba(0, 0, 0, 0.3);
   --shadow-lg: 0 4px 12px rgba(0, 0, 0, 0.5);
-  --color-focus: #90caf9;
+  --color-focus: #F5B700;
   --focus-ring: 0 0 0 2px var(--color-focus);
 }
 
@@ -177,7 +181,7 @@ body {
 
 .btn-primary {
   background: var(--color-primary);
-  color: white;
+  color: #1f1f1f;
 }
 .btn-primary:hover { background: var(--color-primary-hover); }
 .btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
@@ -967,12 +971,15 @@ body {
   outline-offset: 1px;
 }
 
-/* AC7: Visual accent when a non-custom sort is active — #1565c0 on column header bg ≥ 3:1 */
+/* AC7: Visual accent when a non-custom sort is active — gold on column header bg ≥ 3:1 */
 .column-sort-active {
   border-color: var(--color-primary);
   color: var(--color-primary);
   font-weight: 600;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='%231976d2'/%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='%23C49200'/%3E%3C/svg%3E");
+}
+[data-theme="dark"] .column-sort-active {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='%23F5B700'/%3E%3C/svg%3E");
 }
 
 .column-count {


### PR DESCRIPTION
Closes #190

## Changes
- Replaced blue primary tokens with gold: `--color-primary` (#C49200 light / #F5B700 dark), `--color-primary-hover`, `--color-primary-rgb`, `--color-focus`
- Added `--color-accent: #F5B700` token in both light and dark modes for logo/branding
- Updated `HiveLogo` to use `var(--color-accent)` instead of `var(--color-primary)`
- Changed `.btn-primary` text from `white` to `#1f1f1f` for WCAG AA contrast (5.95:1)
- Updated `.column-sort-active` SVG chevron fill to gold per mode
- Added `[data-theme="dark"] .column-sort-active` dark mode override
- Zero blue hex remnants (#1976d2, #90caf9, #1565c0, #64b5f6)
- 22 new tests covering all 6 ACs; 1066 total passing