### PR TITLE
feat: update Hive icon to gold hexagonal SVG

### DIFF
--- a/frontend/public/hive-favicon.svg
+++ b/frontend/public/hive-favicon.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-  <polygon points="12 2 21 7 21 17 12 22 3 17 3 7" fill="#1976d2"/>
+  <polygon points="12 2 21 7 21 17 12 22 3 17 3 7" fill="#F5B700"/>
   <path d="M6.5 12.8l3.4 3.4L17.5 9.2" fill="none" stroke="white" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/frontend/public/hive-icon-192-maskable.svg
+++ b/frontend/public/hive-icon-192-maskable.svg
@@ -1,5 +1,5 @@
 <svg viewBox="0 0 192 192" xmlns="http://www.w3.org/2000/svg">
-  <rect width="192" height="192" fill="#1976d2"/>
+  <rect width="192" height="192" fill="#F5B700"/>
   <g transform="translate(48, 48)">
     <polygon points="48 8 84 26 84 62 48 80 12 62 12 26" fill="none" stroke="white" stroke-width="5"/>
     <path d="M35 47l10.8 10.8L66 36.8" fill="none" stroke="white" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>

--- a/frontend/public/hive-icon-192.svg
+++ b/frontend/public/hive-icon-192.svg
@@ -1,5 +1,5 @@
 <svg viewBox="0 0 192 192" xmlns="http://www.w3.org/2000/svg">
-  <rect width="192" height="192" rx="32" fill="#1976d2"/>
+  <rect width="192" height="192" rx="32" fill="#F5B700"/>
   <g transform="translate(36, 36)">
     <polygon points="60 10 105 32.5 105 77.5 60 100 15 77.5 15 32.5" fill="none" stroke="white" stroke-width="6"/>
     <path d="M43 58.4l13.6 13.6L85 45.2" fill="none" stroke="white" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/>

--- a/frontend/public/hive-icon-512-maskable.svg
+++ b/frontend/public/hive-icon-512-maskable.svg
@@ -1,5 +1,5 @@
 <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
-  <rect width="512" height="512" fill="#1976d2"/>
+  <rect width="512" height="512" fill="#F5B700"/>
   <g transform="translate(128, 128)">
     <polygon points="128 21.3 224 69.3 224 165.3 128 213.3 32 165.3 32 69.3" fill="none" stroke="white" stroke-width="13"/>
     <path d="M92 124.3l28.8 28.8L185 96.3" fill="none" stroke="white" stroke-width="21" stroke-linecap="round" stroke-linejoin="round"/>

--- a/frontend/public/hive-icon-512.svg
+++ b/frontend/public/hive-icon-512.svg
@@ -1,5 +1,5 @@
 <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
-  <rect width="512" height="512" rx="80" fill="#1976d2"/>
+  <rect width="512" height="512" rx="80" fill="#F5B700"/>
   <g transform="translate(96, 96)">
     <polygon points="160 26.7 280 86.7 280 206.7 160 266.7 40 206.7 40 86.7" fill="none" stroke="white" stroke-width="16"/>
     <path d="M115 155.4l36 36L231 120.4" fill="none" stroke="white" stroke-width="26" stroke-linecap="round" stroke-linejoin="round"/>

--- a/frontend/public/logo.svg
+++ b/frontend/public/logo.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-  <polygon points="12 2 21 7 21 17 12 22 3 17 3 7" fill="#1976d2"/>
+  <polygon points="12 2 21 7 21 17 12 22 3 17 3 7" fill="#F5B700"/>
   <path d="M6.5 12.8l3.4 3.4L17.5 9.2" fill="none" stroke="white" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -4,8 +4,8 @@
   "description": "Family task management board powered by Google Sheets",
   "start_url": "/hive/",
   "display": "standalone",
-  "background_color": "#f8f9fa",
-  "theme_color": "#1976d2",
+  "background_color": "#F5B700",
+  "theme_color": "#F5B700",
   "icons": [
     {
       "src": "hive-icon-192.svg",

--- a/frontend/src/favicon.test.ts
+++ b/frontend/src/favicon.test.ts
@@ -10,6 +10,43 @@ const indexPath = resolve(__dirname, '../index.html');
 // @ts-ignore
 const logoPath = resolve(__dirname, '../public/logo.svg');
 
+// @ts-ignore
+const faviconPath = resolve(__dirname, '../public/hive-favicon.svg');
+// @ts-ignore
+const manifestPath = resolve(__dirname, '../public/manifest.json');
+
+const iconFiles = [
+  'hive-icon-192.svg',
+  'hive-icon-192-maskable.svg',
+  'hive-icon-512.svg',
+  'hive-icon-512-maskable.svg',
+];
+
+describe('Gold icon branding (Issue #188)', () => {
+  it('AC4: favicon SVG uses gold fill #F5B700', () => {
+    const svg = readFileSync(faviconPath, 'utf-8');
+    expect(svg).toContain('#F5B700');
+    expect(svg).not.toContain('#1976d2');
+  });
+
+  it.each(iconFiles)('AC5: %s uses gold rect fill #F5B700', (file) => {
+    // @ts-ignore
+    const svg = readFileSync(resolve(__dirname, '../public', file), 'utf-8');
+    expect(svg).toContain('fill="#F5B700"');
+    expect(svg).not.toContain('#1976d2');
+  });
+
+  it('AC5: manifest.json theme_color is #F5B700', () => {
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+    expect(manifest.theme_color).toBe('#F5B700');
+  });
+
+  it('AC5: manifest.json background_color is #F5B700', () => {
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+    expect(manifest.background_color).toBe('#F5B700');
+  });
+});
+
 describe('Favicon (Issue #30 AC2)', () => {
   it('index.html references hive-favicon.svg as the favicon', () => {
     const html = readFileSync(indexPath, 'utf-8');
@@ -25,6 +62,6 @@ describe('Favicon (Issue #30 AC2)', () => {
   it('logo.svg exists in the public directory', () => {
     const svg = readFileSync(logoPath, 'utf-8');
     expect(svg).toContain('<svg');
-    expect(svg).toContain('#1976d2');
+    expect(svg).toContain('#F5B700');
   });
 });


### PR DESCRIPTION
Closes #188

## Changes
- Updated hive-favicon.svg polygon fill from #1976d2 to #F5B700
- Updated all 4 PWA manifest icon SVGs (192/512/maskable) rect fill to #F5B700
- Updated logo.svg fill to #F5B700
- Updated manifest.json: theme_color and background_color to #F5B700
- 7 new tests covering AC4 (favicon) and AC5 (PWA icons + manifest)
- AC1-AC3 already satisfied by #190 (HiveLogo uses var(--color-accent))
- 1073 total tests passing