### PR TITLE
feat: Upcoming view UX improvements — board tiles, single filter bar, header sep (#200)

### DIFF
--- a/frontend/src/components/board/kanban-board.tsx
+++ b/frontend/src/components/board/kanban-board.tsx
@@ -283,6 +283,7 @@ export function KanbanBoard() {
         <div class="board-header-left">
           <HiveLogo class="board-header-logo" />
           <h1>Hive</h1>
+          <span class="board-header-brand-sep" aria-hidden="true" />
           {/* AC1 #198: View mode tabs in header */}
           <div class="control-bar-view-tabs" role="group" aria-label="View" data-testid="control-bar-view-tabs">
             <button

--- a/frontend/src/components/header/control-bar.test.tsx
+++ b/frontend/src/components/header/control-bar.test.tsx
@@ -13,6 +13,7 @@ const { mockState, mockSwitchBoard, mockSetViewMode } = vi.hoisted(() => ({
     activeBoard: { name: 'Work', color: '#ff0000' } as any,
     userBoardRole: 'owner' as string | null,
     viewMode: 'board' as string,
+    activeView: 'board' as string,
     filterLabel: null as string | null,
     filterSearch: '',
     filterDue: null as string | null,
@@ -69,7 +70,7 @@ vi.mock('../../state/board-store', () => ({
     set value(v: boolean) { mockState.showShareModal = v; },
   },
   openDetailWithTitleEdit: { value: false },
-  activeView: { value: 'board' },
+  activeView: { get value() { return mockState.activeView; } },
 }));
 
 afterEach(() => {
@@ -95,6 +96,7 @@ beforeEach(() => {
   mockState.groupBy = 'none';
   mockState.showCreateBoardModal = false;
   mockState.showShareModal = false;
+  mockState.activeView = 'board';
   mockState.rootItems = [
     { id: '1', title: 'Task 1' },
     { id: '2', title: 'Task 2' },
@@ -471,6 +473,20 @@ describe('ControlBar', () => {
       const { container } = render(<ControlBar />);
       const todayChip = container.querySelector('[data-testid="filter-due-today"]');
       expect(todayChip!.getAttribute('aria-pressed')).toBe('false');
+    });
+  });
+
+  describe('Upcoming view — hidden control bar', () => {
+    it('renders nothing when activeView is upcoming', () => {
+      mockState.activeView = 'upcoming';
+      const { container } = render(<ControlBar />);
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('renders normally when activeView is board', () => {
+      mockState.activeView = 'board';
+      const { container } = render(<ControlBar />);
+      expect(container.querySelector('[data-testid="control-bar"]')).not.toBeNull();
     });
   });
 });

--- a/frontend/src/components/header/control-bar.tsx
+++ b/frontend/src/components/header/control-bar.tsx
@@ -164,6 +164,8 @@ export function ControlBar() {
 
   const isUpcoming = activeView.value === 'upcoming';
 
+  if (isUpcoming) return null;
+
   return (
     <div class="control-bar" data-testid="control-bar">
       {/* Board selector — hidden in upcoming view */}

--- a/frontend/src/components/upcoming/upcoming-view.test.tsx
+++ b/frontend/src/components/upcoming/upcoming-view.test.tsx
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/preact';
+import { UpcomingView } from './upcoming-view';
+
+const { mockState, mockToggleUpcomingBoard } = vi.hoisted(() => ({
+  mockState: {
+    upcomingBuckets: [] as any[],
+    upcomingFilterSearch: '',
+    upcomingFilterBoards: new Set(['b1', 'b2']) as Set<string>,
+    accessibleBoards: [
+      { id: 'b1', name: 'Work', icon: '💼', color: '#4a90e2' },
+      { id: 'b2', name: 'Home', icon: '🏠', color: '#7ed321' },
+    ] as any[],
+    boards: [
+      { id: 'b1', name: 'Work', icon: '💼', color: '#4a90e2' },
+      { id: 'b2', name: 'Home', icon: '🏠', color: '#7ed321' },
+    ] as any[],
+    items: [] as any[],
+    selectedItemId: null as string | null,
+    openDetailWithTitleEdit: false,
+  },
+  mockToggleUpcomingBoard: vi.fn(),
+}));
+
+vi.mock('../../state/board-store', () => ({
+  upcomingBuckets: { get value() { return mockState.upcomingBuckets; } },
+  upcomingFilterSearch: {
+    get value() { return mockState.upcomingFilterSearch; },
+    set value(v: string) { mockState.upcomingFilterSearch = v; },
+  },
+  upcomingFilterBoards: { get value() { return mockState.upcomingFilterBoards; } },
+  toggleUpcomingBoard: (...args: any[]) => mockToggleUpcomingBoard(...args),
+  accessibleBoards: { get value() { return mockState.accessibleBoards; } },
+  boards: { get value() { return mockState.boards; } },
+  items: { get value() { return mockState.items; } },
+  selectedItemId: {
+    get value() { return mockState.selectedItemId; },
+    set value(v: string | null) { mockState.selectedItemId = v; },
+  },
+  openDetailWithTitleEdit: {
+    get value() { return mockState.openDetailWithTitleEdit; },
+    set value(v: boolean) { mockState.openDetailWithTitleEdit = v; },
+  },
+  getChildCount: () => ({ total: 0, done: 0 }),
+}));
+
+afterEach(() => {
+  cleanup();
+  mockToggleUpcomingBoard.mockClear();
+});
+
+beforeEach(() => {
+  mockState.upcomingBuckets = [];
+  mockState.upcomingFilterSearch = '';
+  mockState.upcomingFilterBoards = new Set(['b1', 'b2']);
+  mockState.accessibleBoards = [
+    { id: 'b1', name: 'Work', icon: '💼', color: '#4a90e2' },
+    { id: 'b2', name: 'Home', icon: '🏠', color: '#7ed321' },
+  ];
+  mockState.boards = [
+    { id: 'b1', name: 'Work', icon: '💼', color: '#4a90e2' },
+    { id: 'b2', name: 'Home', icon: '🏠', color: '#7ed321' },
+  ];
+  mockState.items = [];
+  Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1280 });
+});
+
+describe('UpcomingView', () => {
+  describe('Board filter tiles', () => {
+    it('renders board tiles instead of dropdown', () => {
+      const { container } = render(<UpcomingView />);
+      expect(container.querySelector('[data-testid="upcoming-board-tiles"]')).not.toBeNull();
+      expect(container.querySelector('[data-testid="upcoming-board-filter-toggle"]')).toBeNull();
+      expect(container.querySelector('[data-testid="upcoming-board-checkboxes"]')).toBeNull();
+    });
+
+    it('renders one tile per accessible board', () => {
+      const { container } = render(<UpcomingView />);
+      const tiles = container.querySelectorAll('[data-testid^="upcoming-board-tile-"]');
+      expect(tiles.length).toBe(2);
+    });
+
+    it('active tile has upcoming-board-tile-active class and aria-pressed="true"', () => {
+      mockState.upcomingFilterBoards = new Set(['b1', 'b2']);
+      const { container } = render(<UpcomingView />);
+      const tile = container.querySelector('[data-testid="upcoming-board-tile-b1"]');
+      expect(tile!.classList.contains('upcoming-board-tile-active')).toBe(true);
+      expect(tile!.getAttribute('aria-pressed')).toBe('true');
+    });
+
+    it('inactive tile has aria-pressed="false" and lacks active class', () => {
+      mockState.upcomingFilterBoards = new Set(['b1']); // b2 excluded
+      const { container } = render(<UpcomingView />);
+      const tile = container.querySelector('[data-testid="upcoming-board-tile-b2"]');
+      expect(tile!.classList.contains('upcoming-board-tile-active')).toBe(false);
+      expect(tile!.getAttribute('aria-pressed')).toBe('false');
+    });
+
+    it('clicking a tile calls toggleUpcomingBoard with its id', () => {
+      const { container } = render(<UpcomingView />);
+      fireEvent.click(container.querySelector('[data-testid="upcoming-board-tile-b1"]') as HTMLElement);
+      expect(mockToggleUpcomingBoard).toHaveBeenCalledWith('b1');
+    });
+
+    it('tiles show board icon and name', () => {
+      const { container } = render(<UpcomingView />);
+      const tile = container.querySelector('[data-testid="upcoming-board-tile-b1"]');
+      expect(tile!.textContent).toContain('💼');
+      expect(tile!.textContent).toContain('Work');
+    });
+
+    it('tiles use --board-color CSS custom property', () => {
+      const { container } = render(<UpcomingView />);
+      const tile = container.querySelector('[data-testid="upcoming-board-tile-b1"]') as HTMLElement;
+      expect(tile.style.getPropertyValue('--board-color')).toBe('#4a90e2');
+    });
+
+    it('board tile group has role="group" and aria-label', () => {
+      const { container } = render(<UpcomingView />);
+      const group = container.querySelector('[data-testid="upcoming-board-tiles"]');
+      expect(group!.getAttribute('role')).toBe('group');
+      expect(group!.getAttribute('aria-label')).toBe('Filter by board');
+    });
+  });
+
+  describe('No label chips in filter bar', () => {
+    it('has no "Filter by label" group', () => {
+      const { container } = render(<UpcomingView />);
+      expect(container.querySelector('[aria-label="Filter by label"]')).toBeNull();
+    });
+
+    it('has no Label: chip group label text', () => {
+      const { container } = render(<UpcomingView />);
+      const labels = Array.from(container.querySelectorAll('.filter-chip-group-label'));
+      expect(labels.find(l => l.textContent === 'Label:')).toBeUndefined();
+    });
+  });
+
+  describe('Filter bar', () => {
+    it('renders search input', () => {
+      const { container } = render(<UpcomingView />);
+      const input = container.querySelector('[data-testid="upcoming-search-input"]') as HTMLInputElement;
+      expect(input).not.toBeNull();
+      expect(input.placeholder).toBe('Search cards...');
+    });
+
+    it('active filter count excludes labels', () => {
+      mockState.upcomingFilterSearch = 'test';
+      mockState.upcomingFilterBoards = new Set(['b1']); // b2 excluded = 1 board filter active
+      const { container } = render(<UpcomingView />);
+      const badge = container.querySelector('.filter-badge');
+      expect(badge).not.toBeNull();
+      expect(badge!.textContent).toBe('2'); // search + board filter
+    });
+
+    it('no filter badge when all boards selected and no search', () => {
+      mockState.upcomingFilterSearch = '';
+      mockState.upcomingFilterBoards = new Set(['b1', 'b2']);
+      const { container } = render(<UpcomingView />);
+      const badge = container.querySelector('.filter-badge');
+      expect(badge).toBeNull();
+    });
+  });
+
+  describe('Empty state', () => {
+    it('shows empty message when no buckets', () => {
+      mockState.upcomingBuckets = [];
+      const { container } = render(<UpcomingView />);
+      expect(container.querySelector('[data-testid="upcoming-empty"]')).not.toBeNull();
+    });
+  });
+
+  describe('Mobile collapse', () => {
+    it('filter content is collapsed on mobile by default', () => {
+      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 500 });
+      const { container } = render(<UpcomingView />);
+      const content = container.querySelector('[data-testid="upcoming-filter-content"]');
+      expect(content!.className).toContain('upcoming-filter-content-collapsed');
+    });
+
+    it('filter toggle button is present', () => {
+      const { container } = render(<UpcomingView />);
+      expect(container.querySelector('[data-testid="upcoming-filter-toggle"]')).not.toBeNull();
+    });
+  });
+});

--- a/frontend/src/components/upcoming/upcoming-view.tsx
+++ b/frontend/src/components/upcoming/upcoming-view.tsx
@@ -2,10 +2,8 @@ import { useState, useCallback, useRef, useEffect } from 'preact/hooks';
 import {
   upcomingBuckets,
   upcomingFilterSearch,
-  upcomingFilterLabel,
   upcomingFilterBoards,
   toggleUpcomingBoard,
-  labels as labelsStore,
   accessibleBoards,
   boards,
   items,
@@ -22,7 +20,6 @@ export function UpcomingView() {
   const [localSearch, setLocalSearch] = useState('');
   const searchRef = useRef<HTMLInputElement>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const [boardFilterOpen, setBoardFilterOpen] = useState(false);
   const [filtersExpanded, setFiltersExpanded] = useState(false);
 
   // Mobile detect
@@ -67,7 +64,6 @@ export function UpcomingView() {
 
   const activeFilterCount =
     (upcomingFilterSearch.value ? 1 : 0) +
-    (upcomingFilterLabel.value ? 1 : 0) +
     (selectedBoardCount < totalBoardCount ? 1 : 0);
 
   return (
@@ -115,62 +111,29 @@ export function UpcomingView() {
             )}
           </div>
 
-          {/* Label chips */}
-          <div role="group" aria-label="Filter by label" class="filter-chip-group">
-            <span class="filter-chip-group-label">Label:</span>
-            {labelsStore.value.map(l => {
-              const active = upcomingFilterLabel.value === l.label;
+          {/* Board filter tiles */}
+          <div
+            role="group"
+            aria-label="Filter by board"
+            class="upcoming-board-tiles"
+            data-testid="upcoming-board-tiles"
+          >
+            {accessibleBoards.value.map(b => {
+              const active = upcomingFilterBoards.value.has(b.id);
               return (
                 <button
-                  key={l.label}
-                  class={`filter-chip filter-chip-label${active ? ' filter-chip-active' : ''}`}
+                  key={b.id}
+                  class={`upcoming-board-tile${active ? ' upcoming-board-tile-active' : ''}`}
                   aria-pressed={active ? 'true' : 'false'}
-                  style={`--label-color: ${l.color}`}
-                  onClick={() => { upcomingFilterLabel.value = active ? null : l.label; }}
+                  style={`--board-color: ${b.color || '#999'}`}
+                  onClick={() => toggleUpcomingBoard(b.id)}
+                  data-testid={`upcoming-board-tile-${b.id}`}
                 >
-                  {l.label}
+                  {b.icon && <span aria-hidden="true">{b.icon}</span>}
+                  {b.name}
                 </button>
               );
             })}
-          </div>
-
-          {/* Board filter */}
-          <div class="upcoming-board-filter" data-testid="upcoming-board-filter">
-            <button
-              class="upcoming-board-filter-toggle"
-              aria-expanded={boardFilterOpen}
-              aria-controls="upcoming-board-checkboxes"
-              onClick={() => setBoardFilterOpen(prev => !prev)}
-              data-testid="upcoming-board-filter-toggle"
-            >
-              Boards ({selectedBoardCount}/{totalBoardCount})
-              <span class={`upcoming-board-filter-chevron${boardFilterOpen ? ' open' : ''}`}>&#9660;</span>
-            </button>
-            {boardFilterOpen && (
-              <div
-                id="upcoming-board-checkboxes"
-                role="group"
-                aria-label="Filter by board"
-                class="upcoming-board-checkboxes"
-                data-testid="upcoming-board-checkboxes"
-              >
-                {accessibleBoards.value.map(b => {
-                  const checked = upcomingFilterBoards.value.has(b.id);
-                  return (
-                    <label key={b.id} class="upcoming-board-checkbox-label">
-                      <input
-                        type="checkbox"
-                        checked={checked}
-                        onChange={() => toggleUpcomingBoard(b.id)}
-                        data-testid={`upcoming-board-checkbox-${b.id}`}
-                      />
-                      {b.icon && <span aria-hidden="true">{b.icon} </span>}
-                      {b.name}
-                    </label>
-                  );
-                })}
-              </div>
-            )}
           </div>
         </div>
       </div>

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -382,6 +382,14 @@ body {
   font-weight: 700;
 }
 
+.board-header-brand-sep {
+  width: 0;
+  height: 18px;
+  border-left: 1px solid var(--color-border);
+  flex-shrink: 0;
+  margin: 0 8px;
+}
+
 .board-header-right {
   display: flex;
   align-items: center;
@@ -1374,12 +1382,12 @@ body {
 
 .board-switcher-select {
   padding: 6px 12px;
-  border: 2px solid var(--color-primary);
+  border: 1px solid var(--color-border);
   border-radius: var(--radius);
   font-size: 14px;
-  font-weight: 600;
+  font-weight: 500;
   font-family: inherit;
-  color: var(--color-primary);
+  color: var(--color-text);
   background: var(--color-surface);
   cursor: pointer;
   min-height: 36px;
@@ -3644,7 +3652,7 @@ body {
 
 .view-tab-active {
   background: var(--color-surface);
-  color: var(--color-text);
+  color: var(--color-primary);
   box-shadow: 0 1px 2px var(--overlay-md);
 }
 
@@ -3671,74 +3679,42 @@ body {
   display: none;
 }
 
-.upcoming-board-filter {
-  position: relative;
-}
-
-.upcoming-board-filter-toggle {
+/* === Board filter tiles (replaces dropdown) === */
+.upcoming-board-tiles {
   display: flex;
-  align-items: center;
+  flex-wrap: wrap;
   gap: 6px;
-  padding: 4px 10px;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
-  background: var(--color-surface);
-  color: var(--color-text);
-  font-size: 13px;
-  cursor: pointer;
-  min-height: 44px;
-}
-
-.upcoming-board-filter-toggle:focus-visible {
-  outline: 2px solid var(--color-primary);
-  outline-offset: -2px;
-}
-
-.upcoming-board-filter-chevron {
-  font-size: 10px;
-  transition: transform 0.15s;
-}
-
-.upcoming-board-filter-chevron.open {
-  transform: rotate(180deg);
-}
-
-.upcoming-board-checkboxes {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  margin-top: 4px;
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius);
-  box-shadow: var(--shadow-lg);
-  padding: 8px;
-  z-index: 10;
-  min-width: 200px;
-}
-
-.upcoming-board-checkbox-label {
-  display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 6px 8px;
-  border-radius: var(--radius-sm);
+}
+
+.upcoming-board-tile {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 10px;
+  border: 2px solid var(--board-color, #999);
+  border-radius: 14px;
+  background: transparent;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--color-text);
   cursor: pointer;
-  font-size: 13px;
-  min-height: 44px;
+  white-space: nowrap;
+  transition: background var(--transition-fast), opacity var(--transition-fast);
+  opacity: 0.45;
 }
 
-.upcoming-board-checkbox-label:hover {
-  background: var(--overlay-sm);
+.upcoming-board-tile:hover {
+  background: color-mix(in srgb, var(--board-color, #999) 15%, transparent);
+  opacity: 1;
 }
 
-.upcoming-board-checkbox-label input[type="checkbox"] {
-  width: 18px;
-  height: 18px;
-  accent-color: var(--color-primary);
+.upcoming-board-tile-active {
+  background: color-mix(in srgb, var(--board-color, #999) 15%, transparent);
+  opacity: 1;
 }
 
-.upcoming-board-checkbox-label input[type="checkbox"]:focus-visible {
+.upcoming-board-tile:focus-visible {
   outline: 2px solid var(--color-primary);
   outline-offset: 2px;
 }
@@ -3838,11 +3814,7 @@ body {
     grid-template-columns: 1fr;
   }
 
-  .upcoming-board-filter-toggle {
-    min-height: 44px;
-  }
-
-  .upcoming-board-checkbox-label {
+  .upcoming-board-tile {
     min-height: 44px;
   }
 }


### PR DESCRIPTION
Closes #200

## Summary
- **Fix double filter bar**: `ControlBar` now returns `null` in Upcoming view — the upcoming view manages its own filters
- **Board filter tiles**: Replaced "Boards (N/N)" dropdown with inline pill tiles using the board's color and icon
- **Remove label chips**: Simplified Upcoming filter to search + board tiles only
- **Header separator**: Vertical rule between "Hive" brand and Board/Upcoming tabs
- **Active tab gold text**: Selected tab now uses `var(--color-primary)` for clear distinction
- **Neutral board dropdown**: Removed distracting gold border/text from board-switcher-select

## Test plan
- [ ] All 1121 tests pass (`cd frontend && npm test`)
- [ ] Board view: header separator visible, "Board" tab gold, board dropdown neutral
- [ ] Upcoming view: single filter bar, board tiles with icons/colors, no label chips
- [ ] Board tiles toggle boards in/out of filter correctly
- [ ] Mobile: Filters collapse works, board tiles min-height 44px

🤖 Generated with [Claude Code](https://claude.com/claude-code)