### PR TITLE
fix: column header wrapping, desktop expand default, terminal toggle swap

### DIFF
--- a/frontend/src/components/board/card-detail.test.tsx
+++ b/frontend/src/components/board/card-detail.test.tsx
@@ -1490,6 +1490,98 @@ describe('CardDetail expand panel (Issue #206)', () => {
   });
 });
 
+describe('CardDetail expand default on desktop (Issue #233)', () => {
+  beforeEach(() => {
+    mockSelectedItemId = 'detail-test-1';
+    mockChildren = [];
+    mockItems = [];
+  });
+
+  it('AC1: opens expanded on desktop viewport (matchMedia matches)', () => {
+    // Mock matchMedia to return true for desktop breakpoint
+    const originalMatchMedia = window.matchMedia;
+    window.matchMedia = (query: string) => ({
+      matches: query === '(min-width: 769px)',
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    } as unknown as MediaQueryList);
+
+    const { container } = renderCardDetail();
+    expect(container.querySelector('.detail-panel-expanded')).not.toBeNull();
+    expect(container.querySelector('[aria-label="Collapse panel"]')).not.toBeNull();
+
+    window.matchMedia = originalMatchMedia;
+  });
+
+  it('AC2: opens collapsed on mobile viewport (matchMedia does not match)', () => {
+    // Default stub returns matches: false — simulates mobile
+    const { container } = renderCardDetail();
+    expect(container.querySelector('.detail-panel-expanded')).toBeNull();
+    expect(container.querySelector('[aria-label="Expand panel"]')).not.toBeNull();
+  });
+
+  it('AC3: user can still toggle manually on desktop', () => {
+    const originalMatchMedia = window.matchMedia;
+    window.matchMedia = (query: string) => ({
+      matches: query === '(min-width: 769px)',
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    } as unknown as MediaQueryList);
+
+    const { container } = renderCardDetail();
+    // Starts expanded on desktop
+    expect(container.querySelector('.detail-panel-expanded')).not.toBeNull();
+
+    // Click collapse
+    const collapseBtn = container.querySelector('[aria-label="Collapse panel"]') as HTMLElement;
+    fireEvent.click(collapseBtn);
+    expect(container.querySelector('.detail-panel-expanded')).toBeNull();
+
+    window.matchMedia = originalMatchMedia;
+  });
+
+  it('AC4: desktop default reapplied when switching tasks', () => {
+    const originalMatchMedia = window.matchMedia;
+    window.matchMedia = (query: string) => ({
+      matches: query === '(min-width: 769px)',
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    } as unknown as MediaQueryList);
+
+    const { container, rerender } = renderCardDetail();
+    // Manually collapse
+    const collapseBtn = container.querySelector('[aria-label="Collapse panel"]') as HTMLElement;
+    fireEvent.click(collapseBtn);
+    expect(container.querySelector('.detail-panel-expanded')).toBeNull();
+
+    // Switch to different item — should re-expand
+    mockSelectedItemId = 'detail-test-2';
+    rerender(
+      <AuthContext.Provider value={mockAuth}>
+        <CardDetail />
+      </AuthContext.Provider>
+    );
+    expect(container.querySelector('.detail-panel-expanded')).not.toBeNull();
+
+    window.matchMedia = originalMatchMedia;
+  });
+});
+
 describe('CardDetail clear date button (Issue #207)', () => {
   beforeEach(() => {
     mockSelectedItemId = 'detail-test-1';

--- a/frontend/src/components/board/card-detail.tsx
+++ b/frontend/src/components/board/card-detail.tsx
@@ -64,11 +64,12 @@ export function CardDetail() {
   const incompleteChildren = children.filter(c => !isTerminalStatus(c.status));
   const doneChildren = children.filter(c => isTerminalStatus(c.status));
 
-  // #206: Expand/collapse panel state
-  const [expanded, setExpanded] = useState(false);
+  // #206: Expand/collapse panel state — #233: default expanded on desktop
+  const isDesktop = () => window.matchMedia('(min-width: 769px)').matches;
+  const [expanded, setExpanded] = useState(isDesktop);
   // Reset expanded state when item changes (AC4)
   useEffect(() => {
-    setExpanded(false);
+    setExpanded(isDesktop());
   }, [item.id]);
 
   const [confirmingDelete, setConfirmingDelete] = useState(false);

--- a/frontend/src/components/settings/column-settings.test.tsx
+++ b/frontend/src/components/settings/column-settings.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, cleanup, waitFor, act } from '@testing-library/preact';
+import { signal } from '@preact/signals';
+import type { BoardStatus, ItemWithRow } from '../../api/types';
+
+const { mockStatuses, mockItems } = vi.hoisted(() => {
+  const { signal } = require('@preact/signals');
+  return {
+    mockStatuses: signal([]),
+    mockItems: signal([]),
+  };
+});
+
+vi.mock('../../state/board-store', () => ({
+  boardStatuses: mockStatuses,
+  boardItems: mockItems,
+}));
+
+const mockUpdateStatus = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../../state/actions', () => ({
+  createStatus: vi.fn().mockResolvedValue(undefined),
+  updateStatus: (...args: any[]) => mockUpdateStatus(...args),
+  reorderStatuses: vi.fn().mockResolvedValue(undefined),
+  deleteStatusWithMigration: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { ColumnSettings } from './column-settings';
+
+function makeStatus(overrides: Partial<BoardStatus> = {}): BoardStatus {
+  return {
+    id: 's1',
+    board_id: 'board-1',
+    name: 'To Do',
+    sort_order: 1,
+    color: '#e3f2fd',
+    is_terminal: false,
+    created_at: '2026-01-01',
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('ColumnSettings terminal toggle (Issue #234)', () => {
+  beforeEach(() => {
+    mockUpdateStatus.mockReset().mockResolvedValue(undefined);
+    mockItems.value = [];
+  });
+
+  it('AC1: toggling a non-terminal column swaps it with the current terminal', async () => {
+    mockStatuses.value = [
+      makeStatus({ id: 's1', name: 'To Do', is_terminal: false }),
+      makeStatus({ id: 's2', name: 'In Progress', is_terminal: false }),
+      makeStatus({ id: 's3', name: 'Done', is_terminal: true }),
+    ];
+
+    const { container } = render(<ColumnSettings token="test-token" />);
+
+    const toggles = container.querySelectorAll('.column-settings-terminal-toggle input[type="checkbox"]');
+    expect(toggles.length).toBe(3);
+
+    // Toggle "To Do" (index 0) which is non-terminal
+    await act(async () => {
+      fireEvent.change(toggles[0]);
+    });
+
+    // Should first turn off "Done" (s3), then turn on "To Do" (s1)
+    await waitFor(() => {
+      expect(mockUpdateStatus).toHaveBeenCalledWith('s3', { is_terminal: false }, 'test-token');
+      expect(mockUpdateStatus).toHaveBeenCalledWith('s1', { is_terminal: true }, 'test-token');
+    });
+  });
+
+  it('AC2: clicking the current terminal column does nothing', () => {
+    mockStatuses.value = [
+      makeStatus({ id: 's1', name: 'To Do', is_terminal: false }),
+      makeStatus({ id: 's3', name: 'Done', is_terminal: true }),
+    ];
+
+    const { container } = render(<ColumnSettings token="test-token" />);
+
+    const toggles = container.querySelectorAll('.column-settings-terminal-toggle input[type="checkbox"]');
+    // The terminal checkbox (Done, index 1) should be disabled
+    expect((toggles[1] as HTMLInputElement).disabled).toBe(true);
+
+    // Firing change should not trigger updateStatus
+    fireEvent.change(toggles[1]);
+    expect(mockUpdateStatus).not.toHaveBeenCalled();
+  });
+
+  it('AC2: terminal toggle checkbox is disabled for the current completion column', () => {
+    mockStatuses.value = [
+      makeStatus({ id: 's1', name: 'To Do', is_terminal: false }),
+      makeStatus({ id: 's2', name: 'Done', is_terminal: true }),
+    ];
+
+    const { container } = render(<ColumnSettings token="test-token" />);
+
+    const toggles = container.querySelectorAll('.column-settings-terminal-toggle input[type="checkbox"]');
+    // Non-terminal should be enabled
+    expect((toggles[0] as HTMLInputElement).disabled).toBe(false);
+    // Terminal should be disabled
+    expect((toggles[1] as HTMLInputElement).disabled).toBe(true);
+  });
+
+  it('shows descriptive tooltip on terminal column', () => {
+    mockStatuses.value = [
+      makeStatus({ id: 's1', name: 'To Do', is_terminal: false }),
+      makeStatus({ id: 's2', name: 'Done', is_terminal: true }),
+    ];
+
+    const { container } = render(<ColumnSettings token="test-token" />);
+
+    const labels = container.querySelectorAll('.column-settings-terminal-toggle');
+    expect((labels[1] as HTMLElement).title).toContain('click another column to change');
+    expect((labels[0] as HTMLElement).title).toContain('Set as completion column');
+  });
+});

--- a/frontend/src/components/settings/column-settings.tsx
+++ b/frontend/src/components/settings/column-settings.tsx
@@ -85,11 +85,16 @@ export function ColumnSettings({ token }: ColumnSettingsProps) {
     await updateStatus(col.id, { color: newColor }, token);
   };
 
-  // --- Terminal toggle ---
+  // --- Terminal toggle (#234: swap — exactly one completion column) ---
   const handleTerminalToggle = async (col: BoardStatus) => {
-    const terminalCount = columns.filter(c => c.is_terminal).length;
-    if (col.is_terminal && terminalCount <= 1) return;
-    await updateStatus(col.id, { is_terminal: !col.is_terminal }, token);
+    // If already terminal, do nothing (user must pick a different column to swap)
+    if (col.is_terminal) return;
+    // Turn off existing terminal column(s), then turn on the new one
+    const currentTerminals = columns.filter(c => c.is_terminal);
+    for (const t of currentTerminals) {
+      await updateStatus(t.id, { is_terminal: false }, token);
+    }
+    await updateStatus(col.id, { is_terminal: true }, token);
   };
 
   // --- Reorder ---
@@ -230,12 +235,12 @@ export function ColumnSettings({ token }: ColumnSettingsProps) {
               <span class="column-settings-count">{itemCount}</span>
 
               {/* Terminal toggle */}
-              <label class="column-settings-terminal-toggle" title="Completion column">
+              <label class="column-settings-terminal-toggle" title={col.is_terminal ? 'Completion column — click another column to change' : 'Set as completion column'}>
                 <input
                   type="checkbox"
                   checked={col.is_terminal}
                   onChange={() => handleTerminalToggle(col)}
-                  disabled={col.is_terminal && terminalCount <= 1}
+                  disabled={col.is_terminal}
                 />
                 <span class="column-settings-terminal-icon">{col.is_terminal ? '\u2713' : ''}</span>
               </label>

--- a/frontend/src/design-tokens.test.ts
+++ b/frontend/src/design-tokens.test.ts
@@ -401,3 +401,40 @@ describe('Design token: --color-primary-light (Issue #104)', () => {
     });
   });
 });
+
+describe('Column header text wrapping (Issue #232)', () => {
+  // Helper to extract a CSS rule block by selector
+  function extractRule(selector: string): string {
+    const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const re = new RegExp(escaped + '\\s*\\{([^}]*?)\\}');
+    const match = css.match(re);
+    return match ? match[1] : '';
+  }
+
+  it('AC1: .column-header-row uses align-items: flex-start for text wrapping', () => {
+    const rule = extractRule('.column-header-row');
+    expect(rule).toContain('align-items: flex-start');
+  });
+
+  it('AC1: .column-header h2 has flex sizing for wrapping', () => {
+    const rule = extractRule('.column-header h2');
+    expect(rule).toContain('flex: 1 1 0');
+    expect(rule).toContain('min-width: 0');
+    expect(rule).toContain('word-break: break-word');
+  });
+
+  it('AC2: .column-count has flex-shrink: 0', () => {
+    const rule = extractRule('.column-count');
+    expect(rule).toContain('flex-shrink: 0');
+  });
+
+  it('AC2: .column-add-btn has flex-shrink: 0', () => {
+    const rule = extractRule('.column-add-btn');
+    expect(rule).toContain('flex-shrink: 0');
+  });
+
+  it('AC2: .column-sort-select has flex-shrink: 0', () => {
+    const rule = extractRule('.column-sort-select');
+    expect(rule).toContain('flex-shrink: 0');
+  });
+});

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -919,7 +919,7 @@ body {
 
 .column-header-row {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
 }
 
@@ -969,6 +969,7 @@ body {
   cursor: pointer;
   min-height: 24px;
   font-family: inherit;
+  flex-shrink: 0;
 }
 
 .column-sort-select:disabled {
@@ -987,6 +988,9 @@ body {
   text-transform: uppercase;
   letter-spacing: 0.5px;
   color: var(--color-text-secondary);
+  flex: 1 1 0;
+  min-width: 0;
+  word-break: break-word;
 }
 
 .column-sort-select {
@@ -1029,6 +1033,7 @@ body {
   padding: 4px 8px;
   border-radius: 10px;
   margin-left: 6px;
+  flex-shrink: 0;
 }
 
 /* Header "+" button — always visible in board view */
@@ -1036,6 +1041,7 @@ body {
   margin-left: auto;
   width: 28px;
   height: 28px;
+  flex-shrink: 0;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Summary
- **#232**: CSS fix for column header text wrapping — `h2` gets `flex: 1 1 0`, `min-width: 0`, `word-break: break-word`; header row uses `align-items: flex-start`; count/add/sort controls get `flex-shrink: 0`
- **#233**: Detail panel opens expanded by default on desktop (≥769px) — uses `matchMedia` to initialize and reset `expanded` state
- **#234**: Terminal column toggle enforces exactly one completion column — swap instead of allowing multiple; current terminal checkbox is always disabled

Closes #232, closes #233, closes #234

## Test plan
- [x] CSS structural tests for #232 (design-tokens.test.ts)
- [x] CardDetail expand tests for #233 with matchMedia mock (card-detail.test.tsx)
- [x] ColumnSettings terminal toggle tests for #234 (column-settings.test.tsx)
- [x] All 183 tests passing
- [x] Visual verification in demo mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)